### PR TITLE
LSN-6635 - Persist device registration state

### DIFF
--- a/General/DeviceRegistration/DeviceRegistrationWorker.swift
+++ b/General/DeviceRegistration/DeviceRegistrationWorker.swift
@@ -14,45 +14,52 @@ import RxCocoa
 class DeviceRegistrationWorker: DeviceRegistering {
 
     var sdkReady: Bool { deviceRegisteredSubject.value }
-    let deviceId: String
+    var deviceId: String { staticDeviceInformation.deviceId }
 
-    private let deviceModel: String
-    private let osVersion: String
-    private let sdkVersion: String
+    private let staticDeviceInformation: StaticDeviceInformation
     private let reachabilityChecker: ReachabilityChecking
     private let loopHandler: DeviceRegistrationLoopHandling
     private let deviceRegisteredSubject: CurrentValueSubject<Bool, Never>
+    private let store: CodableStorageProtocol
+    private let storeKey = "DeviceRegistrationState"
 
     var device: Device {
-        Device(deviceId: deviceId,
-               model: deviceModel,
-               sdkVersion: sdkVersion,
-               osVersion: osVersion,
+        Device(deviceId: staticDeviceInformation.deviceId,
+               model: staticDeviceInformation.deviceModel,
+               sdkVersion: staticDeviceInformation.sdkVersion,
+               osVersion: staticDeviceInformation.osVersion,
                bluetoothOn: reachabilityChecker.isBluetoothConnected,
                wifiConnected: reachabilityChecker.isConnectedToWifi)
     }
 
     init(
-        deviceId: String,
-        deviceModel: String,
-        osVersion: String,
-        sdkVersion: String,
+        staticDeviceInformation: StaticDeviceInformation,
         reachabilityChecker: ReachabilityChecking,
         loopHandler: DeviceRegistrationLoopHandling,
-        deviceRegisteredSubject: CurrentValueSubject<Bool, Never>
+        deviceRegisteredSubject: CurrentValueSubject<Bool, Never>,
+        store: CodableStorageProtocol
     ) {
-        self.deviceId = deviceId
-        self.deviceModel = deviceModel
-        self.osVersion = osVersion
-        self.sdkVersion = sdkVersion
+        self.staticDeviceInformation = staticDeviceInformation
         self.reachabilityChecker = reachabilityChecker
         self.loopHandler = loopHandler
         self.deviceRegisteredSubject = deviceRegisteredSubject
+        self.store = store
+        deviceRegisteredSubject.send(getStoredRegistrationValue())
+    }
+
+    func getStoredRegistrationValue() -> Bool {
+        guard let storedState: Bool = try? store.fetch(for: storeKey) else {
+            return false
+        }
+        return storedState
     }
 
     func registerDevice(_ completion: @escaping () -> Void) {
         loopHandler.registerDevice(device) {
-            self.deviceRegisteredSubject.send(true)
+            if !self.deviceRegisteredSubject.value {
+                try? self.store.save(true, for: self.storeKey)
+                self.deviceRegisteredSubject.send(true)
+            }
             completion()
         }
     }

--- a/General/DeviceRegistration/StaticDeviceInformation.swift
+++ b/General/DeviceRegistration/StaticDeviceInformation.swift
@@ -1,0 +1,16 @@
+//
+//  StaticDeviceInformation.swift
+//  RealifeTechTests
+//
+//  Created by Olivier Butler on 26/10/2020.
+//  Copyright © 2020 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public struct StaticDeviceInformation {
+    let deviceId: String
+    let deviceModel: String
+    let osVersion: String
+    let sdkVersion: String
+}

--- a/General/GeneralFactory.swift
+++ b/General/GeneralFactory.swift
@@ -11,24 +11,22 @@ import Combine
 
 public enum GeneralFactory {
     public static func makeGeneralModule(
-        deviceId: String,
-        deviceModel: String,
-        osVersion: String,
-        sdkVersion: String,
+        staticDeviceInformation: StaticDeviceInformation,
         reachabilityChecker: ReachabilityChecking,
         deviceRegisteredSubject: CurrentValueSubject<Bool, Never>
     ) -> General {
         let deviceRegistrationLoopHandler = DeviceRegistrationLoopHandler(
             reachabilityChecker: reachabilityChecker,
             debounceRateSeconds: 10)
+        let deviceRegistrationStore = CodableStorage(
+            storage: UserDefaultsStorage(),
+            storagePrefix: "GeneralDeviceRegistration")
         let deviceRegistrationWorker = DeviceRegistrationWorker(
-            deviceId: deviceId,
-            deviceModel: deviceModel,
-            osVersion: osVersion,
-            sdkVersion: sdkVersion,
+            staticDeviceInformation: staticDeviceInformation,
             reachabilityChecker: reachabilityChecker,
             loopHandler: deviceRegistrationLoopHandler,
-            deviceRegisteredSubject: deviceRegisteredSubject)
+            deviceRegisteredSubject: deviceRegisteredSubject,
+            store: deviceRegistrationStore)
         return GeneralImplementing(deviceRegistrationWorker: deviceRegistrationWorker)
     }
 }

--- a/General/GeneralTests/DeviceRegistrationTests/DeviceRegistrationWorkerTests.swift
+++ b/General/GeneralTests/DeviceRegistrationTests/DeviceRegistrationWorkerTests.swift
@@ -25,29 +25,57 @@ class DeviceRegistrationWorkerTests: XCTestCase {
     private var deviceRegistrationSpy: MockDeviceRegistrationLoopHandler!
     private var mockReachabilityChecker: MockReachabilityChecker!
     private var deviceRegisteredSubject: CurrentValueSubject<Bool, Never>!
+    private var mockStore: MockCodableStore!
 
     override func setUp() {
         deviceRegistrationSpy = MockDeviceRegistrationLoopHandler()
         mockReachabilityChecker = MockReachabilityChecker()
         deviceRegisteredSubject = .init(false)
-        sut = DeviceRegistrationWorker(
+        mockStore = MockCodableStore()
+        let staticInformation = StaticDeviceInformation(
             deviceId: testId,
             deviceModel: testModel,
             osVersion: osVersion,
-            sdkVersion: sdkVersion,
+            sdkVersion: sdkVersion)
+        sut = DeviceRegistrationWorker(
+            staticDeviceInformation: staticInformation,
             reachabilityChecker: mockReachabilityChecker,
             loopHandler: deviceRegistrationSpy,
-            deviceRegisteredSubject: deviceRegisteredSubject)
+            deviceRegisteredSubject: deviceRegisteredSubject,
+            store: mockStore)
     }
 
     func test_initialisation() {
         XCTAssertEqual(sut.deviceId, testId)
     }
 
-    func test_sdkReady() {
+    func test_initialisation_readsFromStore() {
+        mockStore.valueToReturn = true
+        let staticInformation = StaticDeviceInformation(
+            deviceId: testId,
+            deviceModel: testModel,
+            osVersion: osVersion,
+            sdkVersion: sdkVersion)
+        let sutWithCustomStore = DeviceRegistrationWorker(
+            staticDeviceInformation: staticInformation,
+            reachabilityChecker: mockReachabilityChecker,
+            loopHandler: deviceRegistrationSpy,
+            deviceRegisteredSubject: deviceRegisteredSubject,
+            store: mockStore)
+        XCTAssertTrue(sutWithCustomStore.sdkReady)
+    }
+
+    func test_registerDevice_deviceRegistrationStateIsUpdated() {
         XCTAssertFalse(sut.sdkReady)
-        sut.registerDevice { }
+        XCTAssertFalse(deviceRegisteredSubject.value)
+        sut.registerDevice {}
         XCTAssertTrue(sut.sdkReady)
+        XCTAssertTrue(deviceRegisteredSubject.value)
+    }
+
+    func test_registerDevice_savesToStore() {
+        sut.registerDevice {}
+        XCTAssertNotNil(mockStore.valueSaved)
     }
 
     func test_registerDevice_completionCalled() {
@@ -56,18 +84,6 @@ class DeviceRegistrationWorkerTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 0.01)
-    }
-
-    func test_deviceRegistrationState_isUpdated() {
-        XCTAssertFalse(sut.sdkReady)
-        XCTAssertFalse(deviceRegisteredSubject.value)
-        let expectation = XCTestExpectation(description: "Device registration completion")
-        sut.registerDevice {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 0.01)
-        XCTAssertTrue(sut.sdkReady)
-        XCTAssertTrue(deviceRegisteredSubject.value)
     }
 
     func test_registerDevice_deviceIsCorect() {
@@ -98,4 +114,30 @@ private class MockDeviceRegistrationLoopHandler: DeviceRegistrationLoopHandling 
         self.deviceReceived = device
         completion()
     }
+}
+
+private class MockCodableStore: CodableStorageProtocol {
+    enum MockCodableStoreError: Error {
+        case unexpectedMethodCall, noValueSaved
+    }
+
+    var valueToReturn: Any?
+    var valueSaved: Any?
+
+    func fetchAll<T>() throws -> [T] where T : Decodable {
+        throw MockCodableStoreError.unexpectedMethodCall
+    }
+
+    func fetch<T>(for key: String) throws -> T where T : Decodable {
+        guard let value = valueToReturn as? T else {
+            throw MockCodableStoreError.noValueSaved
+        }
+        return value
+    }
+
+    func save<T>(_ value: T, for key: String) throws where T : Encodable {
+        self.valueSaved = value
+    }
+
+    func delete(key: String) {}
 }

--- a/General/GeneralTests/GeneralFactoryTests.swift
+++ b/General/GeneralTests/GeneralFactoryTests.swift
@@ -13,11 +13,13 @@ class GeneralFactoryTests: XCTestCase {
 
     func test_setsDeviceId() {
         let testId = "123"
-        let sut = GeneralFactory.makeGeneralModule(
+        let staticDeviceInformation = StaticDeviceInformation(
             deviceId: testId,
             deviceModel: "any",
             osVersion: "thing",
-            sdkVersion: "version",
+            sdkVersion: "goes")
+        let sut = GeneralFactory.makeGeneralModule(
+            staticDeviceInformation: staticDeviceInformation,
             reachabilityChecker: ReachabilityFactory.makeReachabilityHelper(),
             deviceRegisteredSubject: .init(false))
         XCTAssertEqual(testId, sut.deviceId)

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		488A67CA2541DA9A005C030E /* AnalyticsEventAndCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488A67C92541DA9A005C030E /* AnalyticsEventAndCompletionTests.swift */; };
 		488A680D2546D0D0005C030E /* ReadOnlyCurrentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488A680C2546D0D0005C030E /* ReadOnlyCurrentValue.swift */; };
 		488A68142546D6E6005C030E /* ReadOnlyCurrentValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488A68132546D6E6005C030E /* ReadOnlyCurrentValueTests.swift */; };
+		488A68222546ECE0005C030E /* StaticDeviceInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488A681C2546ECB6005C030E /* StaticDeviceInformation.swift */; };
 		48D6F143251E158E006CA623 /* RealifeTech.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48D6F13A251E158E006CA623 /* RealifeTech.framework */; };
 		48D6F148251E158E006CA623 /* RealifeTechTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D6F147251E158E006CA623 /* RealifeTechTests.swift */; };
 		48D6F14A251E158E006CA623 /* RealifeTech.h in Headers */ = {isa = PBXBuildFile; fileRef = 48D6F13C251E158E006CA623 /* RealifeTech.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -225,6 +226,7 @@
 		488A67C92541DA9A005C030E /* AnalyticsEventAndCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEventAndCompletionTests.swift; sourceTree = "<group>"; };
 		488A680C2546D0D0005C030E /* ReadOnlyCurrentValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyCurrentValue.swift; sourceTree = "<group>"; };
 		488A68132546D6E6005C030E /* ReadOnlyCurrentValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadOnlyCurrentValueTests.swift; sourceTree = "<group>"; };
+		488A681C2546ECB6005C030E /* StaticDeviceInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticDeviceInformation.swift; sourceTree = "<group>"; };
 		48A6845E25277CA2001F8CB1 /* V3APITokenManagable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V3APITokenManagable.swift; sourceTree = "<group>"; };
 		48A6846225279F6C001F8CB1 /* AuthorisationStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthorisationStore.swift; sourceTree = "<group>"; };
 		48A684652527C43C001F8CB1 /* AuthorisationWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorisationWorker.swift; sourceTree = "<group>"; };
@@ -793,6 +795,7 @@
 				48EFE2522539E55400CC6E58 /* DeviceRegistering.swift */,
 				48EFE2512539E55400CC6E58 /* DeviceRegistrationLoopHandler.swift */,
 				48EFE2502539E55400CC6E58 /* DeviceRegistrationWorker.swift */,
+				488A681C2546ECB6005C030E /* StaticDeviceInformation.swift */,
 			);
 			path = DeviceRegistration;
 			sourceTree = "<group>";
@@ -1124,6 +1127,7 @@
 				4889595D2539D89C00B978A9 /* AnalyticsImplementing.swift in Sources */,
 				488958792539D04B00B978A9 /* APIError.swift in Sources */,
 				48EFE2252539E21100CC6E58 /* PushNotificationRegistering.swift in Sources */,
+				488A68222546ECE0005C030E /* StaticDeviceInformation.swift in Sources */,
 				487479A425403E250048F03D /* QueueProviding+AnyQueue.swift in Sources */,
 				4889587E2539D04B00B978A9 /* RequestCreator.swift in Sources */,
 				488959972539DC8600B978A9 /* DiskStorage.swift in Sources */,

--- a/RealifeTech/SDKInterface.swift
+++ b/RealifeTech/SDKInterface.swift
@@ -33,15 +33,18 @@ public class RealifeTech {
             deviceId: deviceHelper.deviceId,
             clientId: configuration.appCode,
             clientSecret: configuration.clientSecret,
-            baseUrl: configuration.apiUrl ?? "")
-        General = GeneralFactory.makeGeneralModule(
+            baseUrl: configuration.apiUrl ?? "") // TODO: fix this
+        let staticDeviceInformation = StaticDeviceInformation(
             deviceId: deviceHelper.deviceId,
             deviceModel: deviceHelper.model,
             osVersion: deviceHelper.osVersion,
-            sdkVersion: moduleVersionString ?? "123", // TODO: Fix this
+            sdkVersion: moduleVersionString ?? "123") // TODO: fix this
+        General = GeneralFactory.makeGeneralModule(
+            staticDeviceInformation: staticDeviceInformation,
             reachabilityChecker: reachabilityChecker,
             deviceRegisteredSubject: deviceRegisteredSubject)
         if let apiUrl = configuration.graphApiUrl, let graphQlUrl = URL(string: apiUrl) {
+            // TODO: This should *not* be optional to execute
             let client = GraphNetwork(graphQLAPIUrl: graphQlUrl,
                                       tokenHelper: apiHelper,
                                       deviceId: deviceHelper.deviceId,

--- a/SupportingModules/Storage/UserDefaultStorage.swift
+++ b/SupportingModules/Storage/UserDefaultStorage.swift
@@ -14,7 +14,7 @@ public struct UserDefaultsStorage {
 
     public init(
         userDefaults: UserDefaults = UserDefaults.standard,
-        dispatchQueue: DispatchQueue = .init(label: "DiskCache.Queue")
+        dispatchQueue: DispatchQueue = .init(label: "UserDefaults.Queue")
     ) {
         self.userDefaults = userDefaults
         self.dispatchQueue = dispatchQueue


### PR DESCRIPTION
The basics here are very simple, we're passing in a Codable storage instance to the General Module's DeviceRegistrationWorker. On initialisation, the Worker checks the store for any saved value, and sets it to memory. Separately, when the worker succeeds in registering, it will save this to the store if required.

Other changes:
The linter was complaining about too many arguments being passed about, so I wrapped some of the device properties in a `StaticDeviceInformation` struct. I think we *may* want to disable that rule as we continue, dependency injection can get pretty verbose but that's ok (I believe).