### PR TITLE
Fixed logging events fails caused by fixed deviceRegisteredValue

### DIFF
--- a/Analytics/AnalyticsFactory.swift
+++ b/Analytics/AnalyticsFactory.swift
@@ -14,14 +14,14 @@ public enum AnalyticsFactory {
     static func makeAnalyticsModule(
         dispatcher: LogEventSending,
         reachabilityHelper: ReachabilityChecking,
-        deviceRegisteredValue: ReadOnlyCurrentValue<Bool>
+        deviceRegistering: DeviceRegistering
     ) -> Analytics {
         let queue = PersistentQueue<AnalyticEventAndCompletion>(name: "analyticsEvent")
         let analyticsLogger = AnalyticsLogger(
             dispatcher: dispatcher,
             reachabilityHelper: reachabilityHelper,
             persistentQueue: AnyQueue(queue),
-            deviceRegisteredValue: deviceRegisteredValue)
+            deviceRegistering: deviceRegistering)
         return AnalyticsImplementing(analyticsLogger: analyticsLogger)
     }
 }

--- a/Analytics/AnalyticsLogging/AnalyticsLogger.swift
+++ b/Analytics/AnalyticsLogging/AnalyticsLogger.swift
@@ -17,7 +17,7 @@ class AnalyticsLogger {
     private let dispatcher: LogEventSending
     private let persistentQueue: AnyQueue<AnalyticEventAndCompletion>
     private let reachabilityHelper: ReachabilityChecking
-    private let deviceRegisteredValue: ReadOnlyCurrentValue<Bool>
+    private let deviceRegistering: DeviceRegistering
 
     private var loopIsRunning: Bool = false
 
@@ -26,13 +26,13 @@ class AnalyticsLogger {
         reachabilityHelper: ReachabilityChecking,
         persistentQueue: AnyQueue<AnalyticEventAndCompletion>,
         failureDebounceSeconds: Double = 45,
-        deviceRegisteredValue: ReadOnlyCurrentValue<Bool>
+        deviceRegistering: DeviceRegistering
     ) {
         self.dispatcher = dispatcher
         self.reachabilityHelper = reachabilityHelper
         self.persistentQueue = persistentQueue
         self.failureDebounceMilliseconds = Int(failureDebounceSeconds * 1000)
-        self.deviceRegisteredValue = deviceRegisteredValue
+        self.deviceRegistering = deviceRegistering
         startLoop()
     }
 
@@ -53,13 +53,13 @@ class AnalyticsLogger {
         let delayTimeForFailure: DispatchTime = .now() + .milliseconds(failureDebounceMilliseconds)
         guard
             reachabilityHelper.hasNetworkConnection,
-            deviceRegisteredValue.value
-            else {
-                DispatchQueue.main.asyncAfter(deadline: delayTimeForFailure) {
-                    queueItem.releaseQueue(.doNothing)
-                    self.startLoop()
-                }
-                return
+            deviceRegistering.sdkReady
+        else {
+            DispatchQueue.main.asyncAfter(deadline: delayTimeForFailure) {
+                queueItem.releaseQueue(.doNothing)
+                self.startLoop()
+            }
+            return
         }
         dispatcher.logEvent(queueItem.item.analyticEvent) { result in
             queueItem.item.analyticCompletion?(result)

--- a/Analytics/Tests/AnalyticsFactoryTests.swift
+++ b/Analytics/Tests/AnalyticsFactoryTests.swift
@@ -16,7 +16,7 @@ final class AnalyticsFactoryTests: XCTestCase {
         let module = AnalyticsFactory.makeAnalyticsModule(
             dispatcher: MockAnalyticsLogger(),
             reachabilityHelper: MockReachabilityChecker(),
-            deviceRegisteredValue: ReadOnlyCurrentValue(from: .init(true)))
+            deviceRegistering: MockDeviceRegistering())
         XCTAssertTrue(module is AnalyticsImplementing)
     }
 
@@ -33,11 +33,20 @@ final class AnalyticsFactoryTests: XCTestCase {
         let module = AnalyticsFactory.makeAnalyticsModule(
             dispatcher: logEventSpy,
             reachabilityHelper: mockReachabilityChecker,
-            deviceRegisteredValue: ReadOnlyCurrentValue(from: .init(true)))
+            deviceRegistering: MockDeviceRegistering())
         module.logEvent(testEvent) { _ in
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 0.01)
         XCTAssertEqual(logEventSpy.eventsLogged.first, testEvent)
+    }
+
+    private final class MockDeviceRegistering: DeviceRegistering {
+
+        var shouldBeReady = true
+        var sdkReady: Bool { shouldBeReady }
+        let deviceId: String = ""
+
+        func registerDevice(_: @escaping () -> Void) { }
     }
 }

--- a/Analytics/Tests/AnalyticsFactoryTests.swift
+++ b/Analytics/Tests/AnalyticsFactoryTests.swift
@@ -40,13 +40,4 @@ final class AnalyticsFactoryTests: XCTestCase {
         wait(for: [expectation], timeout: 0.01)
         XCTAssertEqual(logEventSpy.eventsLogged.first, testEvent)
     }
-
-    private final class MockDeviceRegistering: DeviceRegistering {
-
-        var shouldBeReady = true
-        var sdkReady: Bool { shouldBeReady }
-        let deviceId: String = ""
-
-        func registerDevice(_: @escaping () -> Void) { }
-    }
 }

--- a/Analytics/Tests/AnalyticsLoggingTests/AnalyticsLoggerTests.swift
+++ b/Analytics/Tests/AnalyticsLoggingTests/AnalyticsLoggerTests.swift
@@ -157,7 +157,7 @@ final class AnalyticsLoggerTests: XCTestCase {
     }
 }
 
-private final class MockDeviceRegistering: DeviceRegistering {
+final class MockDeviceRegistering: DeviceRegistering {
 
     var shouldBeReady = true
     var sdkReady: Bool { shouldBeReady }

--- a/RealifeTech/SDKFactory.swift
+++ b/RealifeTech/SDKFactory.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import Combine
 import RealifeTech_CoreSDK
 
 public class RealifeTech {
@@ -39,8 +38,6 @@ public class RealifeTech {
             deviceModel: deviceHelper.model,
             osVersion: deviceHelper.osVersion,
             sdkVersion: moduleVersionString)
-        let deviceRegisteredSubject = CurrentValueSubject<Bool, Never>(false)
-        let deviceRegisteredValue = ReadOnlyCurrentValue(from: deviceRegisteredSubject)
         General = GeneralFactory.makeGeneralModule(
             staticDeviceInformation: staticDeviceInformation,
             reachabilityChecker: reachabilityChecker)
@@ -54,7 +51,7 @@ public class RealifeTech {
             Analytics = AnalyticsFactory.makeAnalyticsModule(
                 dispatcher: dispatcher,
                 reachabilityHelper: reachabilityChecker,
-                deviceRegisteredValue: deviceRegisteredValue)
+                deviceRegistering: General)
         }
         Communicate = CommunicateFactory.makeCommunicateModule()
         CoreFactory.requestValidToken(fromApiHelper: apiHelper) { }


### PR DESCRIPTION
Found an issue that the event never gets logged because the `deviceRegisteredValue` is injected as `false` from the initialiser and the value never changes even when the device registration call is successful.

To resolve this, I inject the entire General in the intialiser of Analytics as the `sdkReady` may be changed when the client registers the device.