### PR TITLE
ID-742 Simplify createWebPage interface

### DIFF
--- a/Content/ContentImplementing.swift
+++ b/Content/ContentImplementing.swift
@@ -21,21 +21,6 @@ public class ContentImplementing: Content {
         forType type: WebPage.`Type`,
         completion: @escaping (Result<WebPage, Error>) -> Void
     ) {
-        makeGetWebPageQuery(by: type, completion: completion)
-    }
-
-    public func createWebPageView(
-        forType type: WebPage.`Type`,
-        webPgaeViewControllerDelegate: WebPageViewControllerDelegate?,
-        completion: @escaping (UIViewController) -> Void
-    ) {
-        makeGetWebPageQuery(by: type) { result in
-            let webPageViewController = WebPageViewController(result: result, delegate: webPgaeViewControllerDelegate)
-            completion(webPageViewController)
-        }
-    }
-
-    private func makeGetWebPageQuery(by type: WebPage.`Type`, completion: @escaping (Result<WebPage, Error>) -> Void) {
         let pageType = ApolloWebPageType(rawValue: type.rawValue)
         dispatcher.dispatch(
             query: ApolloType.GetWebPageByTypeQuery(type: pageType),
@@ -53,5 +38,15 @@ public class ContentImplementing: Content {
                 completion(.failure(error))
             }
         }
+    }
+
+    public func createWebPageView(
+        forType type: WebPage.`Type`,
+        webPgaeViewControllerDelegate: WebPageViewControllerDelegate?
+    ) -> WebPageViewController {
+        return WebPageViewController(
+            webPageCreator: self,
+            type: type,
+            delegate: webPgaeViewControllerDelegate)
     }
 }

--- a/Content/ContentImplementing.swift
+++ b/Content/ContentImplementing.swift
@@ -42,11 +42,11 @@ public class ContentImplementing: Content {
 
     public func createWebPageView(
         forType type: WebPage.`Type`,
-        webPgaeViewControllerDelegate: WebPageViewControllerDelegate?
+        webPageViewControllerDelegate: WebPageViewControllerDelegate?
     ) -> WebPageViewController {
         return WebPageViewController(
             webPageCreator: self,
             type: type,
-            delegate: webPgaeViewControllerDelegate)
+            delegate: webPageViewControllerDelegate)
     }
 }

--- a/Content/Resources/en.lproj/Content.strings
+++ b/Content/Resources/en.lproj/Content.strings
@@ -7,6 +7,6 @@
 */
 
 "ERROR" = "Error";
-"EMPTYURL_ERROR_MESSAGE" = "URL is empty";
-"CONSTRUCTURL_ERROR_MESSAGE" = "Unable to construct the URL";
+"EMPTY_URL_ERROR_MESSAGE" = "URL is empty";
+"CONSTRUCT_URL_ERROR_MESSAGE" = "Unable to construct the URL";
 "CLOSE" = "Close";

--- a/Content/Tests/ContentImplementingTests.swift
+++ b/Content/Tests/ContentImplementingTests.swift
@@ -79,19 +79,12 @@ final class ContentImplementingTests: XCTestCase {
         wait(for: [expectation], timeout: 0.01)
     }
 
-    func test_createWebPageView_completeWithViewControllerAndPassedResult() {
-        let expectation = XCTestExpectation(description: "Completion gets fulfilled")
-        sut.createWebPageView(forType: .about, webPgaeViewControllerDelegate: nil) { viewController in
-            guard
-                let webPageViewController = viewController as? WebPageViewController,
-                case let .success(webPage) = webPageViewController.result
-            else {
-                return XCTFail("This test should return success case")
-            }
-            XCTAssertEqual(webPage.url.absoluteString, dummyUrl)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 0.01)
+    func test_createWebPageView_returnWebPageViewController() {
+        let delegate = MockWebPageViewControllerDelegate()
+        let result = sut.createWebPageView(
+            forType: .about,
+            webPgaeViewControllerDelegate: delegate)
+        XCTAssertTrue(result.delegate is MockWebPageViewControllerDelegate)
     }
 }
 
@@ -135,4 +128,9 @@ private final class MockGraphQLDispatcher: GraphQLDispatching {
         mutation: Query,
         completion:  @escaping (Result<GraphQLResult<Query.Data>, Error>) -> Void
     ) { }
+}
+
+private final class MockWebPageViewControllerDelegate: WebPageViewControllerDelegate {
+
+    func getError(_ error: Error) { }
 }

--- a/Content/Tests/ContentImplementingTests.swift
+++ b/Content/Tests/ContentImplementingTests.swift
@@ -83,7 +83,7 @@ final class ContentImplementingTests: XCTestCase {
         let delegate = MockWebPageViewControllerDelegate()
         let result = sut.createWebPageView(
             forType: .about,
-            webPgaeViewControllerDelegate: delegate)
+            webPageViewControllerDelegate: delegate)
         XCTAssertTrue(result.delegate is MockWebPageViewControllerDelegate)
     }
 }

--- a/Content/Tests/WebPageTests/WebPageViewControllerTests.swift
+++ b/Content/Tests/WebPageTests/WebPageViewControllerTests.swift
@@ -69,7 +69,7 @@ private final class MockWebPageCreator: WebPageCreatable {
 
     func createWebPageView(
         forType type: WebPage.`Type`,
-        webPgaeViewControllerDelegate: WebPageViewControllerDelegate?
+        webPageViewControllerDelegate: WebPageViewControllerDelegate?
     ) -> WebPageViewController {
         return WebPageViewController(
             webPageCreator: MockWebPageCreator(),

--- a/Content/Tests/WebPageTests/WebPageViewControllerTests.swift
+++ b/Content/Tests/WebPageTests/WebPageViewControllerTests.swift
@@ -12,131 +12,77 @@ import WebKit
 
 final class WebPageViewControllerTests: XCTestCase {
 
-    private let webPage = WebPage(url: URL(string: "https://www.google.com")!)
+    private var webPageCreator: MockWebPageCreator!
+    // swiftlint:disable:next weak_delegate
+    private var delegate: MockWebPageViewControllerDelegate!
+    private var sut: WebPageViewController!
 
-    func test_initialise_resultAndDelegateDidSet() {
-        let delegate = MockWebPageViewControllerDelegate()
-        let sut = makeSUT(delegate: delegate)
-        guard case let .success(returnedWebPage) = sut.result else {
-            return XCTFail("Fail to get the success result")
-        }
-        XCTAssertEqual(returnedWebPage.url, webPage.url)
+    override func setUp() {
+        super.setUp()
+        webPageCreator = MockWebPageCreator()
+        delegate = MockWebPageViewControllerDelegate()
+        sut = WebPageViewController(
+            webPageCreator: webPageCreator,
+            type: .about,
+            delegate: delegate)
+    }
+
+    override func tearDown() {
+        delegate = nil
+        webPageCreator = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    func test_initialise_delegateDidSet() {
         XCTAssertTrue(sut.delegate is MockWebPageViewControllerDelegate)
     }
 
-    func test_viewDidLoad_resultIsSuccess_webViewIsSetupAndObserversAreSet() {
-        let sut = makeSUT()
-        XCTAssertNotNil(sut.webView.uiDelegate)
-        XCTAssertNotNil(sut.webView.navigationDelegate)
-        XCTAssertNotNil(sut.canGoBackObserver)
-        XCTAssertNotNil(sut.canGoForwardObserver)
-        XCTAssertNotNil(sut.estimatedProgressObserver)
-    }
-
-    func test_viewDidLoad_resultIsFailure_webViewIsSetupButNotSetupObservers() {
-        let sut = makeSUT(with: false)
-        XCTAssertNotNil(sut.webView.uiDelegate)
-        XCTAssertNotNil(sut.webView.navigationDelegate)
-        XCTAssertNil(sut.canGoBackObserver)
-        XCTAssertNil(sut.canGoForwardObserver)
-        XCTAssertNil(sut.estimatedProgressObserver)
-    }
-
-    func test_viewDidDisappear_webViewIsLoading_shouldStopLoadingAndInvalidateObservers() {
-        let sut = makeSUT()
-        XCTAssertTrue(sut.webView.isLoading)
-        sut.viewDidDisappear(false)
-        XCTAssertNil(sut.canGoBackObserver)
-        XCTAssertNil(sut.canGoForwardObserver)
-        XCTAssertNil(sut.estimatedProgressObserver)
-    }
-
-    func test_webViewDecidePolicyForNavigationAction_withUrl_policyDidReceivedAndDelegateMethodGetsCalled() {
-        let delegate = MockWebPageViewControllerDelegate()
-        let sut = makeSUT(delegate: delegate)
-        var receivedPolicy: WKNavigationActionPolicy?
-        let navigation = createFakeNavigationAction(url: webPage.url)
-        sut.webView(sut.webView, decidePolicyFor: navigation) { receivedPolicy = $0 }
-        XCTAssertEqual(receivedPolicy, .allow)
-        XCTAssertEqual(delegate.urlReceived, webPage.url)
-    }
-
-    func test_webViewDidStartProvisionalNavigation_delegateMethodGetsCalled() {
-        let delegate = MockWebPageViewControllerDelegate()
-        let sut = makeSUT(delegate: delegate)
-        let navigation = createNavigation(url: webPage.url, webView: sut.webView)
-        sut.webView(sut.webView, didStartProvisionalNavigation: navigation)
-        XCTAssertTrue(delegate.startedProvisionalNavigation)
-    }
-
-    func test_webViewDidFinish_delegateMethodGetsCalled() {
-        let delegate = MockWebPageViewControllerDelegate()
-        let sut = makeSUT(delegate: delegate)
-        let navigation = createNavigation(url: webPage.url, webView: sut.webView)
-        sut.webView(sut.webView, didFinish: navigation)
-        XCTAssertTrue(delegate.finishedNavigation)
-    }
-
-    private func makeSUT(
-        with successResult: Bool = true,
-        delegate: WebPageViewControllerDelegate? = nil
-    ) -> WebPageViewController {
-        let sut = WebPageViewController(
-            result: successResult ? .success(webPage) : .failure(DummyError.failure),
-            delegate: delegate)
+    func test_viewDidLoad_fetchSucceed_webViewIsLoading() {
         _ = sut.view
-        return sut
+        XCTAssertTrue(sut.webView.isLoading)
+    }
+
+    func test_viewDidLoad_fetchFailure_delegateGetsError() {
+        webPageCreator.shouldReturnError = true
+        _ = sut.view
+        XCTAssertFalse(sut.webView.isLoading)
+        XCTAssertTrue(delegate.errorReceived is DummyError)
     }
 }
 
 // MARK: - Mocks
 
+private let webPage = WebPage(url: URL(string: "https://www.google.com")!)
+
+private final class MockWebPageCreator: WebPageCreatable {
+
+    var shouldReturnError = false
+
+    func getWebPage(forType type: WebPage.`Type`, completion: @escaping (Result<WebPage, Error>) -> Void) {
+        if shouldReturnError {
+            completion(.failure(DummyError.failure))
+        } else {
+            completion(.success(webPage))
+        }
+    }
+
+    func createWebPageView(
+        forType type: WebPage.`Type`,
+        webPgaeViewControllerDelegate: WebPageViewControllerDelegate?
+    ) -> WebPageViewController {
+        return WebPageViewController(
+            webPageCreator: MockWebPageCreator(),
+            type: .about,
+            delegate: nil)
+    }
+}
+
 private final class MockWebPageViewControllerDelegate: WebPageViewControllerDelegate {
 
-    var urlReceived: URL?
-    var startedProvisionalNavigation = false
-    var finishedNavigation = false
+    var errorReceived: Error?
 
-    func webViewCanGoBack() { }
-
-    func webViewCanGoForward() { }
-
-    func webViewEstimatedProgressChanged(_ progress: Double) { }
-
-    func urlForNavigationAction(_ url: URL?) {
-        urlReceived = url
+    func getError(_ error: Error) {
+        errorReceived = error
     }
-
-    func webViewDidStartProvisionalNavigation() {
-        startedProvisionalNavigation = true
-    }
-
-    func webViewDidFinishNavigation() {
-        finishedNavigation = true
-    }
-}
-
-private final class FakeNavigationAction: WKNavigationAction {
-
-    let testRequest: URLRequest
-
-    override var request: URLRequest {
-        return testRequest
-    }
-
-    init(testRequest: URLRequest) {
-        self.testRequest = testRequest
-        super.init()
-    }
-}
-
-// MARK: - Helper
-
-private func createFakeNavigationAction(url: URL) -> FakeNavigationAction {
-    return FakeNavigationAction(testRequest: URLRequest(url: url))
-}
-
-private func createNavigation(url: URL, webView: WKWebView) -> WKNavigation? {
-    let urlRequest = URLRequest(url: url)
-    return webView.load(urlRequest)
 }

--- a/Content/WebPage/WebPageCreatable.swift
+++ b/Content/WebPage/WebPageCreatable.swift
@@ -14,6 +14,6 @@ public protocol WebPageCreatable {
         completion: @escaping (Result<WebPage, Error>) -> Void)
     func createWebPageView(
         forType type: WebPage.`Type`,
-        webPgaeViewControllerDelegate: WebPageViewControllerDelegate?,
-        completion: @escaping (UIViewController) -> Void)
+        webPgaeViewControllerDelegate: WebPageViewControllerDelegate?
+    ) -> WebPageViewController
 }

--- a/Content/WebPage/WebPageCreatable.swift
+++ b/Content/WebPage/WebPageCreatable.swift
@@ -14,6 +14,6 @@ public protocol WebPageCreatable {
         completion: @escaping (Result<WebPage, Error>) -> Void)
     func createWebPageView(
         forType type: WebPage.`Type`,
-        webPgaeViewControllerDelegate: WebPageViewControllerDelegate?
+        webPageViewControllerDelegate: WebPageViewControllerDelegate?
     ) -> WebPageViewController
 }

--- a/Content/WebPage/WebPageViewController.swift
+++ b/Content/WebPage/WebPageViewController.swift
@@ -10,44 +10,40 @@ import UIKit
 import WebKit
 
 public protocol WebPageViewControllerDelegate: AnyObject {
-    func webViewCanGoBack()
-    func webViewCanGoForward()
-    func webViewEstimatedProgressChanged(_ progress: Double)
-    func urlForNavigationAction(_ url: URL?)
-    func webViewDidStartProvisionalNavigation()
-    func webViewDidFinishNavigation()
+    func getError(_: Error)
 }
 
-public class WebPageViewController: UIViewController {
+open class WebPageViewController: UIViewController {
 
-    let result: Result<WebPage, Error>
-    weak var delegate: WebPageViewControllerDelegate?
+    private let webPageCreator: WebPageCreatable
+    private let type: WebPage.`Type`
 
-    private(set) var canGoBackObserver: NSKeyValueObservation?
-    private(set) var canGoForwardObserver: NSKeyValueObservation?
-    private(set) var estimatedProgressObserver: NSKeyValueObservation?
-
-    public lazy var webView: WKWebView = {
+    public weak var delegate: WebPageViewControllerDelegate?
+    open lazy var webView: WKWebView = {
         let webView = WKWebView()
         webView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(webView)
         return webView
     }()
 
-    public init(result: Result<WebPage, Error>, delegate: WebPageViewControllerDelegate?) {
-        self.result = result
+    public init(
+        webPageCreator: WebPageCreatable,
+        type: WebPage.`Type`,
+        delegate: WebPageViewControllerDelegate?
+    ) {
+        self.webPageCreator = webPageCreator
+        self.type = type
         self.delegate = delegate
         super.init(nibName: nil, bundle: nil)
     }
 
-    required init?(coder: NSCoder) {
+    required public init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     public override func viewDidLoad() {
         super.viewDidLoad()
         setupWebView()
-        beginLoading()
+        fetchWebPage()
     }
 
     public override func viewDidDisappear(_ animated: Bool) {
@@ -56,8 +52,7 @@ public class WebPageViewController: UIViewController {
     }
 
     private func setupWebView() {
-        webView.uiDelegate = self
-        webView.navigationDelegate = self
+        view.addSubview(webView)
         NSLayoutConstraint.activate([
             webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             webView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
@@ -66,90 +61,20 @@ public class WebPageViewController: UIViewController {
         ])
     }
 
-    private func beginLoading() {
-        switch result {
-        case .success(let webPage):
-            let request = URLRequest(url: webPage.url)
-            webView.load(request)
-            observeWebView()
-        case .failure(let error):
-            showAlertControllerAndCloseScene(title: error.localizedDescription)
+    private func fetchWebPage() {
+        webPageCreator.getWebPage(forType: type) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let webPage):
+                self.webView.load(URLRequest(url: webPage.url))
+            case .failure(let error):
+                self.delegate?.getError(error)
+            }
         }
     }
 
     private func cancelLoading() {
         guard webView.isLoading else { return }
         webView.stopLoading()
-        guard webView.observationInfo != nil else { return }
-        canGoBackObserver?.invalidate()
-        canGoForwardObserver?.invalidate()
-        estimatedProgressObserver?.invalidate()
-        canGoBackObserver = nil
-        canGoForwardObserver = nil
-        estimatedProgressObserver = nil
-    }
-
-    private func observeWebView() {
-        canGoBackObserver = webView.observe(
-            \.canGoBack,
-            options: .new) { [weak self] (_, _) in
-            self?.delegate?.webViewCanGoBack()
-        }
-        canGoForwardObserver = webView.observe(
-            \.canGoForward,
-            options: .new) { [weak self] (_, _) in
-            self?.delegate?.webViewCanGoForward()
-        }
-        estimatedProgressObserver = webView.observe(
-            \.estimatedProgress,
-            options: .new) { [weak self] (_, change) in
-            self?.delegate?.webViewEstimatedProgressChanged(change.newValue ?? 0)
-        }
-    }
-
-    private func showAlertControllerAndCloseScene(title: String?) {
-        let alertController = UIAlertController(
-            title: title,
-            message: nil,
-            preferredStyle: .alert)
-        let closeAction = UIAlertAction(
-            title: "CLOSE".localizedString,
-            style: .default) { [weak self] _ in
-            self?.dismiss(animated: true, completion: nil)
-        }
-        alertController.addAction(closeAction)
-        present(alertController, animated: true, completion: nil)
-    }
-}
-
-extension WebPageViewController: WKUIDelegate, WKNavigationDelegate {
-
-    public func webView(
-        _ webView: WKWebView,
-        createWebViewWith configuration: WKWebViewConfiguration,
-        for navigationAction: WKNavigationAction,
-        windowFeatures: WKWindowFeatures
-    ) -> WKWebView? {
-        if navigationAction.targetFrame == nil {
-            webView.load(navigationAction.request)
-        }
-        return nil
-    }
-
-    public func webView(
-        _ webView: WKWebView,
-        decidePolicyFor navigationAction: WKNavigationAction,
-        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
-    ) {
-        delegate?.urlForNavigationAction(navigationAction.request.url)
-        decisionHandler(.allow)
-    }
-
-    public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        delegate?.webViewDidStartProvisionalNavigation()
-    }
-
-    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        delegate?.webViewDidFinishNavigation()
     }
 }

--- a/Content/WebPage/WebPageViewController.swift
+++ b/Content/WebPage/WebPageViewController.swift
@@ -19,7 +19,7 @@ open class WebPageViewController: UIViewController {
     private let type: WebPage.`Type`
 
     public weak var delegate: WebPageViewControllerDelegate?
-    open lazy var webView: WKWebView = {
+    public lazy var webView: WKWebView = {
         let webView = WKWebView()
         webView.translatesAutoresizingMaskIntoConstraints = false
         return webView

--- a/Content/WebPage/WebPageViewController.swift
+++ b/Content/WebPage/WebPageViewController.swift
@@ -19,7 +19,7 @@ open class WebPageViewController: UIViewController {
     private let type: WebPage.`Type`
 
     public weak var delegate: WebPageViewControllerDelegate?
-    public lazy var webView: WKWebView = {
+    public let webView: WKWebView = {
         let webView = WKWebView()
         webView.translatesAutoresizingMaskIntoConstraints = false
         return webView

--- a/DummyProject/DummyProject/ViewController.swift
+++ b/DummyProject/DummyProject/ViewController.swift
@@ -117,13 +117,10 @@ class ViewController: UIViewController {
                 message: "Unable to find this page type")
             return
         }
-        updateLoadingSpinnerVisibility(shouldShow: true)
-        RealifeTech.Content.createWebPageView(
+        let webPageViewController = RealifeTech.Content.createWebPageView(
             forType: pageType,
-            webPgaeViewControllerDelegate: self) { [weak self] viewController in
-            self?.updateLoadingSpinnerVisibility(shouldShow: false)
-            self?.present(viewController, animated: true, completion: nil)
-        }
+            webPgaeViewControllerDelegate: self)
+        present(webPageViewController, animated: true, completion: nil)
     }
 
     // MARK: - Helper methods
@@ -187,28 +184,11 @@ extension ViewController: UIPickerViewDataSource, UIPickerViewDelegate {
 
 extension ViewController: WebPageViewControllerDelegate {
 
-    func webViewCanGoBack() {
-        print("webViewCanGoBack")
-    }
-
-    func webViewCanGoForward() {
-        print("webViewCanGoForward")
-    }
-
-    func webViewEstimatedProgressChanged(_ progress: Double) {
-        print("webViewEstimatedProgressChanged: \(progress)")
-    }
-
-    func urlForNavigationAction(_ url: URL?) {
-        guard let url = url else { return }
-        print("urlForNavigationAction: \(url)")
-    }
-
-    func webViewDidStartProvisionalNavigation() {
-        print("webViewDidStartProvisionalNavigation")
-    }
-
-    func webViewDidFinishNavigation() {
-        print("webViewDidFinishNavigation")
+    func getError(_ error: Error) {
+        presentedViewController?.dismiss(animated: true) {
+            self.showAlertController(
+                title: "Content",
+                message: "Failed to create WebPageViewController due to error: \(error.localizedDescription)")
+        }
     }
 }


### PR DESCRIPTION
This PR simplifies the second method of the Content interface. In the original method, the function makes the query before returning the view controller. However, this approach handles too many UX/UI tasks in the view controller. Therefore, we decide to simplify it by letting the view controller makes the query and only exposes the error if query fails.
```
// from
func createWebPageView(
        forType type: WebPage.`Type`,
        webPgaeViewControllerDelegate: WebPageViewControllerDelegate?,
        completion: @escaping (UIViewController) -> Void)
}
// change to
func createWebPageView(
        forType type: WebPage.`Type`,
        webPgaeViewControllerDelegate: WebPageViewControllerDelegate?
    ) -> WebPageViewController
```