### PR TITLE
ID-742 Add new web page types

### DIFF
--- a/Content/ContentImplementing.swift
+++ b/Content/ContentImplementing.swift
@@ -24,7 +24,7 @@ public class ContentImplementing: Content {
         let pageType = ApolloWebPageType(rawValue: type.rawValue)
         dispatcher.dispatch(
             query: ApolloType.GetWebPageByTypeQuery(type: pageType),
-            cachePolicy: .returnCacheDataElseFetch) { result in
+            cachePolicy: .returnCacheDataAndFetch) { result in
             switch result {
             case .success(let response):
                 guard let urlString = response.data?.getWebPageByType?.url else {

--- a/Content/WebPage/WebPage.swift
+++ b/Content/WebPage/WebPage.swift
@@ -18,7 +18,22 @@ public struct WebPage {
         case privacy
         case about
         case aboutCompany
-        case purchasesHelp
+        case important
+        case info
+        case times
+        case event
+        case welcome
+        case travel
+        case faq
+        case food
+        case program
+        case social
+        case menu
+        case legal
+        case quizHelp
+        case quizTerms
+        case quizWinner
+        case ntpTerms
 
         /// Initialise the `Type` with the plain text which may be camel case, lowercase or uppercase.
         /// Returns nil when there's no corresponding type in WebPage.`Type`

--- a/DummyProject/Podfile.lock
+++ b/DummyProject/Podfile.lock
@@ -5,14 +5,14 @@ PODS:
   - Apollo/SQLite (0.40.0):
     - Apollo/Core
     - SQLite.swift (~> 0.12.2)
-  - RealifeTech-CoreSDK (1.0.5):
+  - RealifeTech-CoreSDK (1.0.7):
     - Apollo (~> 0.40.0)
     - Apollo/SQLite
     - RxCocoa (~> 5.1.1)
     - RxSwift (~> 5.1.1)
     - SwiftLint
   - RealifeTech-SDK (0.0.1):
-    - RealifeTech-CoreSDK (~> 1.0.5)
+    - RealifeTech-CoreSDK (~> 1.0.7)
   - RxCocoa (5.1.1):
     - RxRelay (~> 5)
     - RxSwift (~> 5)
@@ -22,7 +22,7 @@ PODS:
   - SQLite.swift (0.12.2):
     - SQLite.swift/standard (= 0.12.2)
   - SQLite.swift/standard (0.12.2)
-  - SwiftLint (0.42.0)
+  - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - RealifeTech-SDK (from `../`)
@@ -43,14 +43,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Apollo: 9fb70b598511a6212a81a34c00fa9bf8bac19a23
-  RealifeTech-CoreSDK: e5019577ac830153df8d878292dcf415111c3a5e
-  RealifeTech-SDK: dc0665e4e2c5296c42609440074c200ee2663339
+  RealifeTech-CoreSDK: 846cddaf70a068c70a57b911d45c40a0adf54744
+  RealifeTech-SDK: bcf9bdbb4789f90aa37e573b737682655ae1d56b
   RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
   RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
   RxSwift: 1e2e1f9570186967f617e49128ed26ccf1bafc8e
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
-  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
+  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
 PODFILE CHECKSUM: c72ca01018f6498435b6d29c67f4bbc7d08daa04
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.1

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ inhibit_all_warnings!
 workspace 'RealifeTech-SDK'
 project 'RealifeTech-SDK'
 
-pod 'RealifeTech-CoreSDK', '~> 1.0.5'
+pod 'RealifeTech-CoreSDK', '~> 1.0.7'
 
 target 'RealifeTech' do
   use_frameworks!

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - Apollo/SQLite (0.40.0):
     - Apollo/Core
     - SQLite.swift (~> 0.12.2)
-  - RealifeTech-CoreSDK (1.0.5):
+  - RealifeTech-CoreSDK (1.0.7):
     - Apollo (~> 0.40.0)
     - Apollo/SQLite
     - RxCocoa (~> 5.1.1)
@@ -22,10 +22,10 @@ PODS:
   - SQLite.swift (0.12.2):
     - SQLite.swift/standard (= 0.12.2)
   - SQLite.swift/standard (0.12.2)
-  - SwiftLint (0.42.0)
+  - SwiftLint (0.43.1)
 
 DEPENDENCIES:
-  - RealifeTech-CoreSDK (~> 1.0.5)
+  - RealifeTech-CoreSDK (~> 1.0.7)
   - RxTest (~> 5.1.1)
 
 SPEC REPOS:
@@ -41,14 +41,14 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Apollo: 9fb70b598511a6212a81a34c00fa9bf8bac19a23
-  RealifeTech-CoreSDK: e5019577ac830153df8d878292dcf415111c3a5e
+  RealifeTech-CoreSDK: 846cddaf70a068c70a57b911d45c40a0adf54744
   RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
   RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
   RxSwift: 1e2e1f9570186967f617e49128ed26ccf1bafc8e
   RxTest: 711632d5644dffbeb62c936a521b5b008a1e1faa
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
-  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
+  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
-PODFILE CHECKSUM: f66d62246aeb26a323311d3da0f8846f45faa75d
+PODFILE CHECKSUM: 279ff5ac339153da7625a6af62b3f41c1b21fc1e
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.1

--- a/RealifeTech-SDK.podspec
+++ b/RealifeTech-SDK.podspec
@@ -41,6 +41,6 @@ Pod::Spec.new do |spec|
   ]
   spec.resource_bundle = { "RealifeTech" => ["**/*.lproj/*.strings"] }
 
-  spec.dependency "RealifeTech-CoreSDK", "~> 1.0.5"
+  spec.dependency "RealifeTech-CoreSDK", "~> 1.0.7"
 
 end


### PR DESCRIPTION
1. Update Core SDK to 1.0.7
2. Change cachePolicy of `getWebPageByType` to returnCacheAndFetch to sync with Android.