### PR TITLE
ID-963 Customise KeychainKey in AuthorisationStore

### DIFF
--- a/Core/APIUtilities/APIRequester.swift
+++ b/Core/APIUtilities/APIRequester.swift
@@ -48,14 +48,3 @@ extension APIRequester {
         return .formatted(format: dateFormatString(), localeIdentifier: "en_US_POSIX")
     }
 }
-
-extension APIRequester {
-
-    static func format(date: Date, format: String? = nil) -> String {
-        let dateFormat = format ?? dateFormatString()
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = dateFormat
-        return formatter.string(from: date)
-    }
-}

--- a/Core/APIUtilities/APIRequesterHelper.swift
+++ b/Core/APIUtilities/APIRequesterHelper.swift
@@ -29,13 +29,13 @@ public struct APIRequesterHelper {
         OAuthRequester.setDefaultOAuthParameters(clientId: clientId, clientSecret: clientSecret)
         self.baseUrl = baseUrl
         self.deviceId = deviceId
-        let apiTokenManager = constructTokenManager()
+        let apiTokenManager = constructTokenManager(clientId: clientId)
         self.tokenManager = apiTokenManager
         return apiTokenManager
     }
 
-    private static func constructTokenManager() -> APITokenManagable {
-        let authorisationStore = AuthorisationStore()
+    private static func constructTokenManager(clientId: String) -> APITokenManagable {
+        let authorisationStore = AuthorisationStore(clientId: clientId)
         let authorisationWorker = AuthorisationWorker(authorisationStore: authorisationStore)
         let oAuthTokenRefreshWatcher = OAuthTokenRefreshWatcher()
         let oAuthRefreshOrWaitActionGenerator = OAuthRefreshOrWaitActionGenerator(

--- a/Core/APIUtilities/Tests/APIRequesterTests.swift
+++ b/Core/APIUtilities/Tests/APIRequesterTests.swift
@@ -51,16 +51,6 @@ final class APIRequesterTests: XCTestCase {
         }
     }
 
-    func test_format() {
-        let date = Date()
-        let formatter = DateFormatter()
-        formatter.dateFormat = expectedFormat
-        formatter.locale = Locale(identifier: expectedLocale)
-        let expectedResult = formatter.string(from: date)
-        let result = MockRequester.format(date: date)
-        XCTAssertEqual(result, expectedResult)
-    }
-
     func test_interceptors() {
         guard let url = URL(string: "http://test.com") else {
             return XCTFail("Test setup failed")


### PR DESCRIPTION
Since the SDK saves the token with fixed keys to Keychain, and the token may be replaced by other apps that are also imported the SDK due to the same key. Hence, adding the `clientId` to the prefix resolves the problem.