### PR TITLE
Remove Core subspec to resolve the duplicated UUID warning

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -9,16 +9,16 @@ This Xcode project has the following directory/target structure:
 
 ### SDK Project
 * RealifeTech-SDK -  Publically consumed module
-* General 
+* General
 * Communicate
 * Analytics
 * Audiences
-* SupportingModules
+* Core
     * ReachabilityChecker - Tool for checking connectivity options
     * UIDeviceHelper - Wrapper around the UIDevice module
     * APILayer - HTTP API toolset with database like persistance options
-    * APIV3Utilities - Extensions to the APILayer for the V3 API
-    * GraphQL - Apollo GraphQL wrapper 
+    * APIUtilities - Extensions to the APILayer for the V3 API
+    * GraphQL - Apollo GraphQL wrapper
     * Repositories - Contains V3API repositories
     * Storage - Contains various generic data stores
 ### Dummy Project
@@ -30,9 +30,9 @@ This Xcode project has the following directory/target structure:
 Test suites are nested inside the modules.
 
 ## Module setup
-All our main modules (General, Communicate, Analytics etc.), represent collections of use cases. Each set of use cases should be decoupled from eachother, but we want to expose a single interface for the cases (e.g. `General.someTask()`).
+All our main modules (General, Communicate, Analytics etc.), represent collections of use cases. Each set of use cases should be decoupled from each other, but we want to expose a single interface for the cases (e.g. `General.someTask()`).
 
-We use the factory & facade patterns. A single light weight facade exists for each module which fowards calls to the underlying business logic. A factory exists which can build all the business logic and inject it into the facade. This keep the code highly decoupled, makes dependency management super easy, and keeps the configuraion highly flexible.
+We use the factory & facade patterns. A single light weight facade exists for each module which forwards calls to the underlying business logic. A factory exists which can build all the business logic and inject it into the facade. This keep the code highly decoupled, makes dependency management super easy, and keeps the configuration highly flexible.
 
 ### Worked Example: Analytics
 
@@ -43,7 +43,7 @@ We combine these use case protocols into a simple `Analytics` typealias. We defi
 
 ## Dependencies
 
-3rd Party dependencies are managed thorugh CocoaPods. Note that we should actively be moving away from RxSwift and aim to remove the dependencies of the SDK.
+3rd Party dependencies are managed through CocoaPods. Note that we should actively be moving away from RxSwift and aim to remove the dependencies of the SDK.
 
 ## Known Issues
 
@@ -56,7 +56,7 @@ Sometimes after changing between branches which have different projects within t
 ```
 This is caused by problems in the `xcconfig` files, and should stop coming up once the project stucture is stable.
 
-To resolve the issue: 
+To resolve the issue:
 - Go to the relevant target in Xcode
 - Open the Build Setting tab. 
 - Filter for `Always embed swift standard libraries` (you should see it is bold, indicating a custom setting has been saved).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Getting Started
- 
+
 This repository contains the RealifeTech SDK which can be installed into your Swift project using the CocoaPods dependency manager. Here you'll find a guide on getting started, and examples of how to use the SDK's features.
 
 ## 1. Ensure the following requirements are met
@@ -21,18 +21,12 @@ Open your terminal, navigate to the directory containing your podfile, and run:
 $ pod install
 ```
 
-If you would like to use the Core service of the SDK only, add the following line to your `Podfile` under your Apps target:
-``` ruby
-pod 'RealifeTech-SDK/Core'
-```
-
 ## 3. Setup the SDK at runtime
-1. Ensure you configure the SDK before calling any of this methods (see **Configuration** section below). 
+1. Ensure you configure the SDK before calling any of this methods (see **Configuration** section below).
 2. You will also need to complete **Device Registration** (see below) before you can use the rest of the SDK methods.
 
-# Core
+# Configuration
 
-## Configuration
 **Important: Using the SDK without calling configuring can lead to runtime errors. Do not forget to configure the SDK.**
 
 Use the following function to configure the SDK for use. You will be provided the values necessary as part of your onboarding. Note that the SDK provides default values for its API endpoints, unless you are provided with unique endpoints as part of onboarding leave these fields blank.
@@ -48,7 +42,7 @@ RealifeTech.configureSDK(with: configuration)
 ```
 To ensure the SDK is configured before any other functionality is used, we recommend adding the code to your `AppDelegate`'s `applicationDidFinishLaunching(_:)`.
 
-## Setup core services
+# Setup core services
 RealifeTech-SDK/Core provides factory methods in `CoreFactory` to allow you to initialise the services.
 
 1. ***UIDeviceInterface***: A helper to get the UUID, model and system version of the current device.
@@ -88,8 +82,8 @@ Interfacing with our backend systems requires that your device be registered wit
 
 
 ``` swift
-RealifeTech.General.registerDevice { 
-    // code to run once call has finished 
+RealifeTech.General.registerDevice {
+    // code to run once call has finished
 }
 ```
 If the registration fails (for instance due to connectivity issues) we will retry until it is successful. You will not be able to use the majority of the SDK until the device has been registered, and can check the status of it using:
@@ -111,16 +105,16 @@ You'll usually add this code to the AppDelegate method which [receives an APN to
 
 Alternatively, you can register a device token arbitrarily, or after passing it through your own logic. In which case use `registerForPushNotifications(token: String)`.
 
-Until the token has successfully been sent to our backend, it will be stored persistantly. When the app launches, we will attempt to send a pending token. Only one token can be stored at a time. 
+Until the token has successfully been sent to our backend, it will be stored persistantly. When the app launches, we will attempt to send a pending token. Only one token can be stored at a time.
 
 # Analytics
 Use the following function to log an analytic event
 
 ``` swift
 RealifeTech.Analytics.logEvent(
-    type: "type", 
-    action: "action", 
-    new: ["someValue": "123"], 
+    type: "type",
+    action: "action",
+    new: ["someValue": "123"],
     old: nil) { result in
         switch result {
         case success:
@@ -156,7 +150,7 @@ RealifeTech.Audiences.deviceIsMemberOfAudience(audienceId: String) { result in
 
 Note: You may wish to check whether the SDK is ready before calling:
 ``` swift
-guard RealifeTech.General.sdkReady else { 
-    // Handle SDK not yet ready // 
+guard RealifeTech.General.sdkReady else {
+    // Handle SDK not yet ready //
 }
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the RealifeTech SDK which can be installed into your Sw
 * [CocoaPods](https://guides.cocoapods.org/using/getting-started.html) 1.8.4+
 * Swift 5
 
-Note that our SDK currently depends on RxSwift packages which are automatically managed with CocoaPods. This package should be compatible with any peer requirements on RxSwft and RxCocoa versions greater than 4.2.
+Note that our SDK currently depends on RxSwift packages which are automatically managed with CocoaPods. This package should be compatible with any peer requirements on RxSwift and RxCocoa versions greater than 6.1.
 
 ## 2. Install the RealifeTech-SDK Pod dependency
 
@@ -43,7 +43,7 @@ RealifeTech.configureSDK(with: configuration)
 To ensure the SDK is configured before any other functionality is used, we recommend adding the code to your `AppDelegate`'s `applicationDidFinishLaunching(_:)`.
 
 # Setup core services
-RealifeTech-SDK/Core provides factory methods in `CoreFactory` to allow you to initialise the services.
+RealifeTech-SDK provides factory methods in `CoreFactory` to allow you to initialise the services.
 
 1. ***UIDeviceInterface***: A helper to get the UUID, model and system version of the current device.
 ```

--- a/RealifeTech-SDK.podspec
+++ b/RealifeTech-SDK.podspec
@@ -8,9 +8,11 @@ Pod::Spec.new do |spec|
   spec.description  = "This is RealifeTech SDK, it provides integration with RealifeTech backend services, providing functionality such as device notification management, audience membership, and analytics logging. Creating a better experience of the real world for every person."
 
   spec.homepage     = "https://realifetech.com"
-  spec.authors      = { "Jonathon Albert" => "jonathon.albert@live.com",
-			            "Olivier Butler" => "olivier.butler@gmail.com",
-                        "Mickey Lee" => "mickey.lee@realifetech.com" }
+  spec.authors      = [
+    "Jonathon Albert" => "jonathon.albert@live.com",
+    "Olivier Butler" => "olivier.butler@gmail.com",
+    "Mickey Lee" => "mickey.lee@realifetech.com"
+  ]
 
   spec.ios.deployment_target = "13.0"
   spec.swift_version         = "5.0"

--- a/RealifeTech-SDK.podspec
+++ b/RealifeTech-SDK.podspec
@@ -8,46 +8,29 @@ Pod::Spec.new do |spec|
   spec.description  = "This is RealifeTech SDK, it provides integration with RealifeTech backend services, providing functionality such as device notification management, audience membership, and analytics logging. Creating a better experience of the real world for every person."
 
   spec.homepage     = "https://realifetech.com"
-  spec.authors       = { "Jonathon Albert" => "jonathon.albert@live.com",
-			"Olivier Butler" => "olivier.butler@gmail.com" ,
-			"Mickey Lee" => "mickey.lee@realifetech.com" }
+  spec.authors      = { "Jonathon Albert" => "jonathon.albert@live.com",
+			            "Olivier Butler" => "olivier.butler@gmail.com",
+                        "Mickey Lee" => "mickey.lee@realifetech.com" }
 
   spec.ios.deployment_target = "13.0"
-  spec.swift_version = "5.0"
-  spec.source        = { :git => 'https://github.com/realifetech/ios-sdk.git', :branch => 'master', :tag => "#{spec.version}"}
+  spec.swift_version         = "5.0"
+  spec.source                = { :git => 'https://github.com/realifetech/ios-sdk.git', :branch => 'master', :tag => "#{spec.version}"}
 
-  spec.default_subspecs = 'RealifeTech'
+  spec.source_files = [
+    '**/*.swift',
+    'RealifeTech/RealifeTech.h'
+  ]
+  spec.exclude_files = [
+    '**/Tests/**/*',
+    'DummyProject/**/*',
+    'Pods/**/*'
+  ]
+  spec.resource_bundle = { 'RealifeTech' => ['**/Resources/*.lproj/*.strings'] }
 
-  spec.subspec 'Core' do |s|
-    s.source_files = [
-      'Core/**/*.swift',
-      'RealifeTech/RealifeTech.h'
-    ]
-    s.exclude_files = [
-      'Tests/*',
-      '**/Tests/**/*'
-    ]
-    s.resource_bundle = { "RealifeTech" => ["Core/Resources/*.lproj/*.strings"] }
-    s.dependency 'RxSwift', '~> 6.1.0'
-    s.dependency 'RxCocoa', '~> 6.1.0'
-    s.dependency 'Apollo', '~> 0.40.0'
-    s.dependency 'Apollo/SQLite'
-  end
-
-  spec.subspec 'RealifeTech' do |s|
-    s.source_files = [
-      '**/*.swift',
-      'RealifeTech/RealifeTech.h'
-    ]
-    s.exclude_files = [
-      '**/Tests/**/*',
-      'DummyProject/**/*',
-      'Pods/**/*'
-    ]
-    s.resource_bundle = { "RealifeTech" => ["Content/Resources/*.lproj/*.strings"] }
-    s.dependency 'RealifeTech-SDK/Core'
-  end
-
+  spec.dependency 'RxSwift', '~> 6.1.0'
+  spec.dependency 'RxCocoa', '~> 6.1.0'
+  spec.dependency 'Apollo', '~> 0.40.0'
+  spec.dependency 'Apollo/SQLite'
   spec.dependency 'SwiftLint', '~> 0.43.1'
 
 end


### PR DESCRIPTION
Remove the Core subspec as we're going to import the entire library now. 
This also resolves the duplicated UUID warning which is probably caused by adding duplicated resources files in the pod spec.