### PR TITLE
ID-1026 Basket (part 2)

### DIFF
--- a/Analytics/AnalyticsLogging/AnalyticsLogger.swift
+++ b/Analytics/AnalyticsLogging/AnalyticsLogger.swift
@@ -91,7 +91,10 @@ class AnalyticsLogger {
             old: event.oldString,
             version: event.version,
             timestamp: event.timestampString)
-        graphQLManager.dispatchMutation(mutation: ApolloType.PutAnalyticEventMutation(input: input)) { result in
+        graphQLManager.dispatchMutation(
+            mutation: ApolloType.PutAnalyticEventMutation(input: input),
+            cacheResultToPersistence: false
+        ) { result in
             switch result {
             case .success(let success):
                 completion(.success(success.data?.putAnalyticEvent.success ?? false))

--- a/Core/GraphQL/API/sell_fragment_basket.graphql.swift
+++ b/Core/GraphQL/API/sell_fragment_basket.graphql.swift
@@ -25,6 +25,7 @@ public extension ApolloType {
           ...FragmentTimeslot
         }
         collectionDate
+        collectionPreferenceType
         items {
           __typename
           id
@@ -63,6 +64,7 @@ public extension ApolloType {
         GraphQLField("seatInfo", type: .list(.object(SeatInfo.selections))),
         GraphQLField("timeslot", type: .object(Timeslot.selections)),
         GraphQLField("collectionDate", type: .scalar(String.self)),
+        GraphQLField("collectionPreferenceType", type: .scalar(String.self)),
         GraphQLField("items", type: .list(.object(Item.selections))),
       ]
     }
@@ -73,8 +75,8 @@ public extension ApolloType {
       self.resultMap = unsafeResultMap
     }
 
-    public init(grossAmount: Int? = nil, discountAmount: Int? = nil, netAmount: Int? = nil, seatInfo: [SeatInfo?]? = nil, timeslot: Timeslot? = nil, collectionDate: String? = nil, items: [Item?]? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Basket", "grossAmount": grossAmount, "discountAmount": discountAmount, "netAmount": netAmount, "seatInfo": seatInfo.flatMap { (value: [SeatInfo?]) -> [ResultMap?] in value.map { (value: SeatInfo?) -> ResultMap? in value.flatMap { (value: SeatInfo) -> ResultMap in value.resultMap } } }, "timeslot": timeslot.flatMap { (value: Timeslot) -> ResultMap in value.resultMap }, "collectionDate": collectionDate, "items": items.flatMap { (value: [Item?]) -> [ResultMap?] in value.map { (value: Item?) -> ResultMap? in value.flatMap { (value: Item) -> ResultMap in value.resultMap } } }])
+    public init(grossAmount: Int? = nil, discountAmount: Int? = nil, netAmount: Int? = nil, seatInfo: [SeatInfo?]? = nil, timeslot: Timeslot? = nil, collectionDate: String? = nil, collectionPreferenceType: String? = nil, items: [Item?]? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Basket", "grossAmount": grossAmount, "discountAmount": discountAmount, "netAmount": netAmount, "seatInfo": seatInfo.flatMap { (value: [SeatInfo?]) -> [ResultMap?] in value.map { (value: SeatInfo?) -> ResultMap? in value.flatMap { (value: SeatInfo) -> ResultMap in value.resultMap } } }, "timeslot": timeslot.flatMap { (value: Timeslot) -> ResultMap in value.resultMap }, "collectionDate": collectionDate, "collectionPreferenceType": collectionPreferenceType, "items": items.flatMap { (value: [Item?]) -> [ResultMap?] in value.map { (value: Item?) -> ResultMap? in value.flatMap { (value: Item) -> ResultMap in value.resultMap } } }])
     }
 
     public var __typename: String {
@@ -137,6 +139,15 @@ public extension ApolloType {
       }
       set {
         resultMap.updateValue(newValue, forKey: "collectionDate")
+      }
+    }
+
+    public var collectionPreferenceType: String? {
+      get {
+        return resultMap["collectionPreferenceType"] as? String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "collectionPreferenceType")
       }
     }
 

--- a/Core/GraphQL/API/sell_getMyBasket.graphql.swift
+++ b/Core/GraphQL/API/sell_getMyBasket.graphql.swift
@@ -1,0 +1,122 @@
+// @generated
+//  This file was automatically generated and should not be edited.
+
+import Apollo
+import Foundation
+
+/// ApolloType namespace
+public extension ApolloType {
+  final class GetMyBasketQuery: GraphQLQuery {
+    /// The raw GraphQL definition of this operation.
+    public let operationDefinition: String =
+      """
+      query getMyBasket {
+        getMyBasket {
+          __typename
+          ...FragmentBasket
+        }
+      }
+      """
+
+    public let operationName: String = "getMyBasket"
+
+    public var queryDocument: String {
+      var document: String = operationDefinition
+      document.append("\n" + FragmentBasket.fragmentDefinition)
+      document.append("\n" + FragmentTimeslot.fragmentDefinition)
+      document.append("\n" + FragmentFulfilmentPoint.fragmentDefinition)
+      document.append("\n" + FragmentForm.fragmentDefinition)
+      document.append("\n" + FragmentFulfilmentPointCategory.fragmentDefinition)
+      document.append("\n" + FragmentVenue.fragmentDefinition)
+      document.append("\n" + FragmentProductVariant.fragmentDefinition)
+      document.append("\n" + FragmentProduct.fragmentDefinition)
+      document.append("\n" + FragmentProductModifierItem.fragmentDefinition)
+      document.append("\n" + FragmentProductModifierItemSelection.fragmentDefinition)
+      return document
+    }
+
+    public init() {
+    }
+
+    public struct Data: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Query"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("getMyBasket", type: .object(GetMyBasket.selections)),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(getMyBasket: GetMyBasket? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Query", "getMyBasket": getMyBasket.flatMap { (value: GetMyBasket) -> ResultMap in value.resultMap }])
+      }
+
+      public var getMyBasket: GetMyBasket? {
+        get {
+          return (resultMap["getMyBasket"] as? ResultMap).flatMap { GetMyBasket(unsafeResultMap: $0) }
+        }
+        set {
+          resultMap.updateValue(newValue?.resultMap, forKey: "getMyBasket")
+        }
+      }
+
+      public struct GetMyBasket: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["Basket"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLFragmentSpread(FragmentBasket.self),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        public var fragments: Fragments {
+          get {
+            return Fragments(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
+        }
+
+        public struct Fragments {
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public var fragmentBasket: FragmentBasket {
+            get {
+              return FragmentBasket(unsafeResultMap: resultMap)
+            }
+            set {
+              resultMap += newValue.resultMap
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Core/GraphQL/GraphQLFiles/sell_fragment_basket.graphql
+++ b/Core/GraphQL/GraphQLFiles/sell_fragment_basket.graphql
@@ -6,17 +6,28 @@ fragment FragmentBasket on Basket {
     key
     value
   }
-  timeslot { ...FragmentTimeslot }
+  timeslot {
+    ...FragmentTimeslot
+  }
   collectionDate
+  collectionPreferenceType
   items {
     id
     price
     modifierItemsPrice
     quantity
     totalPrice
-    fulfilmentPoint { ...FragmentFulfilmentPoint }
-    productVariant { ...FragmentProductVariant }
-    product { ...FragmentProduct }
-    productModifierItems { ...FragmentProductModifierItemSelection }
+    fulfilmentPoint {
+      ...FragmentFulfilmentPoint
+    }
+    productVariant {
+      ...FragmentProductVariant
+    }
+    product {
+      ...FragmentProduct
+    }
+    productModifierItems {
+      ...FragmentProductModifierItemSelection
+    }
   }
 }

--- a/Core/GraphQL/GraphQLFiles/sell_getMyBasket.graphql
+++ b/Core/GraphQL/GraphQLFiles/sell_getMyBasket.graphql
@@ -1,0 +1,5 @@
+query getMyBasket {
+  getMyBasket {
+    ...FragmentBasket
+  }
+}

--- a/Core/GraphQL/GraphQLManager.swift
+++ b/Core/GraphQL/GraphQLManager.swift
@@ -17,6 +17,7 @@ public protocol GraphQLManageable {
     )
     func dispatchMutation<Mutation: GraphQLMutation>(
         mutation: Mutation,
+        cacheResultToPersistence: Bool,
         completion:  @escaping (Result<GraphQLResult<Mutation.Data>, Error>) -> Void
     )
     func clearAllCachedData()
@@ -50,9 +51,13 @@ extension GraphQLManager: GraphQLManageable {
 
     public func dispatchMutation<Mutation: GraphQLMutation>(
         mutation: Mutation,
+        cacheResultToPersistence: Bool,
         completion:  @escaping (Result<GraphQLResult<Mutation.Data>, Error>) -> Void
     ) {
-        client.perform(mutation: mutation) { result in
+        client.perform(
+            mutation: mutation,
+            publishResultToStore: cacheResultToPersistence
+        ) { result in
             switch result {
             case .success(let graphQLResult):
                 return completion(.success(graphQLResult))

--- a/Core/GraphQL/GraphQLManager.swift
+++ b/Core/GraphQL/GraphQLManager.swift
@@ -39,7 +39,10 @@ extension GraphQLManager: GraphQLManageable {
         cachePolicy: GraphNetworkCachePolicy,
         completion: @escaping (Result<GraphQLResult<Query.Data>, Error>) -> Void
     ) {
-        client.fetch(query: query, cachePolicy: cachePolicy.apolloCachePolicyType) { result in
+        client.fetch(
+            query: query,
+            cachePolicy: cachePolicy.apolloCachePolicyType
+        ) { result in
             switch result {
             case .success(let graphQLResult):
                 return completion(.success(graphQLResult))

--- a/Core/GraphQL/Tests/GraphQLManagerTests.swift
+++ b/Core/GraphQL/Tests/GraphQLManagerTests.swift
@@ -82,7 +82,8 @@ final class GraphQLManagerTests: XCTestCase {
         networkTransport.mutationResultReturns = .success(graphQLResult)
         let expectation = XCTestExpectation(description: "callback is fulfilled")
         sut.dispatchMutation(
-            mutation: UnderTestMutation(input: .dummy)
+            mutation: UnderTestMutation(input: .dummy),
+            cacheResultToPersistence: false
         ) { result in
             guard case let .success(returnedResponse) = result else {
                 return XCTFail("The test should return failure case")
@@ -98,7 +99,8 @@ final class GraphQLManagerTests: XCTestCase {
         networkTransport.mutationResultReturns = .failure(DummyError.failure)
         let expectation = XCTestExpectation(description: "callback is fulfilled")
         sut.dispatchMutation(
-            mutation: UnderTestMutation(input: .dummy)
+            mutation: UnderTestMutation(input: .dummy),
+            cacheResultToPersistence: false
         ) { result in
             guard case let .failure(returnedError) = result else {
                 return XCTFail("The test should return failure case")

--- a/Core/GraphQL/Tests/Utils/MockGraphQLManager.swift
+++ b/Core/GraphQL/Tests/Utils/MockGraphQLManager.swift
@@ -31,6 +31,7 @@ final class MockGraphQLManager<ResultDataType>: GraphQLManageable {
 
     func dispatchMutation<Mutation: GraphQLMutation>(
         mutation: Mutation,
+        cacheResultToPersistence: Bool,
         completion:  @escaping (Result<GraphQLResult<Mutation.Data>, Error>) -> Void
     ) {
         dispatchMutationIsCalled = true

--- a/Core/GraphQL/Utils/String+ISO8601Date.swift
+++ b/Core/GraphQL/Utils/String+ISO8601Date.swift
@@ -1,0 +1,25 @@
+//
+//  String+GraphQLDate.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 25/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+
+    var iso8601Date: Date? {
+        let dateFormatter = ISO8601DateFormatter()
+        return dateFormatter.date(from: self)
+    }
+}
+
+extension Date {
+
+    var iso8601String: String? {
+        let dateFormatter = ISO8601DateFormatter()
+        return dateFormatter.string(from: self)
+    }
+}

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -113,6 +113,14 @@
 		961C1CB726839AE100BE6F3B /* CollectionPreferenceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CB626839AE100BE6F3B /* CollectionPreferenceType.swift */; };
 		961C1CBB26839C2500BE6F3B /* BasketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CBA26839C2500BE6F3B /* BasketItem.swift */; };
 		961C1CBD26839C3700BE6F3B /* SeatInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CBC26839C3700BE6F3B /* SeatInfo.swift */; };
+		961C1CBF26839CBA00BE6F3B /* BasketProvidable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CBE26839CBA00BE6F3B /* BasketProvidable.swift */; };
+		961C1CC126839CC500BE6F3B /* BasketRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CC026839CC500BE6F3B /* BasketRepository.swift */; };
+		961C1CC326839D7300BE6F3B /* BasketInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CC226839D7300BE6F3B /* BasketInput.swift */; };
+		961C1CC72684D3F200BE6F3B /* BasketError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CC62684D3F200BE6F3B /* BasketError.swift */; };
+		961C1CCB2684E3B200BE6F3B /* ProductModifierItemSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CCA2684E3B200BE6F3B /* ProductModifierItemSelection.swift */; };
+		961C1CCD2684EF8600BE6F3B /* BasketItemInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CCC2684EF8600BE6F3B /* BasketItemInput.swift */; };
+		961C1CCF2684EF9C00BE6F3B /* ProductModifierItemSelectionInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CCE2684EF9C00BE6F3B /* ProductModifierItemSelectionInput.swift */; };
+		961C1CD12684EFB400BE6F3B /* CheckoutInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CD02684EFB400BE6F3B /* CheckoutInput.swift */; };
 		961C41CE260882BA001D8467 /* APITokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4162260882B9001D8467 /* APITokenManager.swift */; };
 		961C41CF260882BA001D8467 /* APITokenManagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4163260882B9001D8467 /* APITokenManagable.swift */; };
 		961C41D0260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4165260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift */; };
@@ -350,6 +358,14 @@
 		961C1CB626839AE100BE6F3B /* CollectionPreferenceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionPreferenceType.swift; sourceTree = "<group>"; };
 		961C1CBA26839C2500BE6F3B /* BasketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasketItem.swift; sourceTree = "<group>"; };
 		961C1CBC26839C3700BE6F3B /* SeatInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeatInfo.swift; sourceTree = "<group>"; };
+		961C1CBE26839CBA00BE6F3B /* BasketProvidable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasketProvidable.swift; sourceTree = "<group>"; };
+		961C1CC026839CC500BE6F3B /* BasketRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasketRepository.swift; sourceTree = "<group>"; };
+		961C1CC226839D7300BE6F3B /* BasketInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasketInput.swift; sourceTree = "<group>"; };
+		961C1CC62684D3F200BE6F3B /* BasketError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasketError.swift; sourceTree = "<group>"; };
+		961C1CCA2684E3B200BE6F3B /* ProductModifierItemSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductModifierItemSelection.swift; sourceTree = "<group>"; };
+		961C1CCC2684EF8600BE6F3B /* BasketItemInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasketItemInput.swift; sourceTree = "<group>"; };
+		961C1CCE2684EF9C00BE6F3B /* ProductModifierItemSelectionInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductModifierItemSelectionInput.swift; sourceTree = "<group>"; };
+		961C1CD02684EFB400BE6F3B /* CheckoutInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutInput.swift; sourceTree = "<group>"; };
 		961C4162260882B9001D8467 /* APITokenManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APITokenManager.swift; sourceTree = "<group>"; };
 		961C4163260882B9001D8467 /* APITokenManagable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APITokenManagable.swift; sourceTree = "<group>"; };
 		961C4165260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthRefreshOrWaitActionGenerator.swift; sourceTree = "<group>"; };
@@ -709,6 +725,7 @@
 				9606ED88267B50B000ED24D0 /* ProductFilter.swift */,
 				961C1CA02683400500BE6F3B /* ProductImage.swift */,
 				961C1CA42683404300BE6F3B /* ProductModifierItem.swift */,
+				961C1CCE2684EF9C00BE6F3B /* ProductModifierItemSelectionInput.swift */,
 				961C1CA22683402C00BE6F3B /* ProductModifierList.swift */,
 				961C1CA62683405400BE6F3B /* ProductVariant.swift */,
 			);
@@ -782,8 +799,12 @@
 			isa = PBXGroup;
 			children = (
 				961C1CB426839A5100BE6F3B /* Basket.swift */,
+				961C1CC226839D7300BE6F3B /* BasketInput.swift */,
 				961C1CBA26839C2500BE6F3B /* BasketItem.swift */,
+				961C1CCC2684EF8600BE6F3B /* BasketItemInput.swift */,
+				961C1CD02684EFB400BE6F3B /* CheckoutInput.swift */,
 				961C1CB626839AE100BE6F3B /* CollectionPreferenceType.swift */,
+				961C1CCA2684E3B200BE6F3B /* ProductModifierItemSelection.swift */,
 				961C1CBC26839C3700BE6F3B /* SeatInfo.swift */,
 			);
 			path = Models;
@@ -792,6 +813,9 @@
 		961C1CB326839A4200BE6F3B /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				961C1CBE26839CBA00BE6F3B /* BasketProvidable.swift */,
+				961C1CC026839CC500BE6F3B /* BasketRepository.swift */,
+				961C1CC62684D3F200BE6F3B /* BasketError.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -1558,10 +1582,12 @@
 				48EFE2242539E21100CC6E58 /* CommunicateImplementing.swift in Sources */,
 				961C4227260882BB001D8467 /* RequestDispatcher.swift in Sources */,
 				0319F3382667995B00C01E1F /* content_getWebPageByType.graphql.swift in Sources */,
+				961C1CC72684D3F200BE6F3B /* BasketError.swift in Sources */,
 				0319F32F2667995B00C01E1F /* sell_getFulfilmentPointCategories.graphql.swift in Sources */,
 				964A3BF12680B94E00C42C35 /* GraphQLManagerError.swift in Sources */,
 				961C1C9F26833C8800BE6F3B /* StandardTitleTranslation.swift in Sources */,
 				9606ED8B267B512900ED24D0 /* Product.swift in Sources */,
+				961C1CCF2684EF9C00BE6F3B /* ProductModifierItemSelectionInput.swift in Sources */,
 				0319F3232667995B00C01E1F /* Types.graphql.swift in Sources */,
 				0319F33A2667995B00C01E1F /* sell_fragment_product.graphql.swift in Sources */,
 				961C41D3260882BA001D8467 /* OAuthTokenRefreshWatcher.swift in Sources */,
@@ -1595,15 +1621,18 @@
 				0319F32E2667995B00C01E1F /* sell_getFulfilmentPointById.graphql.swift in Sources */,
 				487479E225408E7D0048F03D /* PushNotificationRegistrar.swift in Sources */,
 				0319F32B2667995B00C01E1F /* canvas_getWidgetsByScreenId.graphql.swift in Sources */,
+				961C1CC126839CC500BE6F3B /* BasketRepository.swift in Sources */,
 				961C4225260882BB001D8467 /* Requester.swift in Sources */,
 				961C4270260882C8001D8467 /* DeviceRequester.swift in Sources */,
 				961C426F260882C8001D8467 /* Device.swift in Sources */,
 				0319F3252667995B00C01E1F /* sell_fragment_productModifierItem.graphql.swift in Sources */,
+				961C1CCD2684EF8600BE6F3B /* BasketItemInput.swift in Sources */,
 				9606ED81267B4FE400ED24D0 /* Sell.swift in Sources */,
 				961C41EC260882BA001D8467 /* RequestLoggingInterceptor.swift in Sources */,
 				961C1CA52683404300BE6F3B /* ProductModifierItem.swift in Sources */,
 				964A3BED2680B49300C42C35 /* FulfilmentPointProvidable.swift in Sources */,
 				48EFE24B2539E52D00CC6E58 /* General.swift in Sources */,
+				961C1CD12684EFB400BE6F3B /* CheckoutInput.swift in Sources */,
 				0319F3142667995B00C01E1F /* sell_addPaymentSourceToMyWallet.graphql.swift in Sources */,
 				0319F31F2667995B00C01E1F /* sell_fragment_paymentSourceDetails.graphql.swift in Sources */,
 				961C1CB0268396F100BE6F3B /* sell_getMyBasket.graphql.swift in Sources */,
@@ -1637,7 +1666,9 @@
 				961C1CA32683402C00BE6F3B /* ProductModifierList.swift in Sources */,
 				961C1C88268204EF00BE6F3B /* FulfilmentPoint.swift in Sources */,
 				961C4264260882C8001D8467 /* QueueProviding+AnyQueue.swift in Sources */,
+				961C1CBF26839CBA00BE6F3B /* BasketProvidable.swift in Sources */,
 				480BCD94251E254D00266617 /* SDKConfiguration.swift in Sources */,
+				961C1CCB2684E3B200BE6F3B /* ProductModifierItemSelection.swift in Sources */,
 				968CA62325EF69370000C2E2 /* ContentFactory.swift in Sources */,
 				961C1CA72683405400BE6F3B /* ProductVariant.swift in Sources */,
 				9606ED97267B646F00ED24D0 /* SellImplementing.swift in Sources */,
@@ -1668,6 +1699,7 @@
 				0319F3372667995B00C01E1F /* sell_fragment_fulfilmentPoint.graphql.swift in Sources */,
 				0319F31A2667995B00C01E1F /* analytics_putAnalyticEvent.graphql.swift in Sources */,
 				968CA5CD25EE7B4C0000C2E2 /* String+ContentLocalization.swift in Sources */,
+				961C1CC326839D7300BE6F3B /* BasketInput.swift in Sources */,
 				961C4217260882BB001D8467 /* APIError.swift in Sources */,
 				0319F3242667995B00C01E1F /* sell_fragment_venue.graphql.swift in Sources */,
 				487479BE2540423D0048F03D /* AnalyticsLogger.swift in Sources */,

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		961C1CCD2684EF8600BE6F3B /* BasketItemInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CCC2684EF8600BE6F3B /* BasketItemInput.swift */; };
 		961C1CCF2684EF9C00BE6F3B /* ProductModifierItemSelectionInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CCE2684EF9C00BE6F3B /* ProductModifierItemSelectionInput.swift */; };
 		961C1CD12684EFB400BE6F3B /* CheckoutInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CD02684EFB400BE6F3B /* CheckoutInput.swift */; };
+		961C1CDD2685F86200BE6F3B /* String+ISO8601Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CDC2685F86200BE6F3B /* String+ISO8601Date.swift */; };
 		961C41CE260882BA001D8467 /* APITokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4162260882B9001D8467 /* APITokenManager.swift */; };
 		961C41CF260882BA001D8467 /* APITokenManagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4163260882B9001D8467 /* APITokenManagable.swift */; };
 		961C41D0260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4165260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift */; };
@@ -366,6 +367,7 @@
 		961C1CCC2684EF8600BE6F3B /* BasketItemInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasketItemInput.swift; sourceTree = "<group>"; };
 		961C1CCE2684EF9C00BE6F3B /* ProductModifierItemSelectionInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductModifierItemSelectionInput.swift; sourceTree = "<group>"; };
 		961C1CD02684EFB400BE6F3B /* CheckoutInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutInput.swift; sourceTree = "<group>"; };
+		961C1CDC2685F86200BE6F3B /* String+ISO8601Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ISO8601Date.swift"; sourceTree = "<group>"; };
 		961C4162260882B9001D8467 /* APITokenManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APITokenManager.swift; sourceTree = "<group>"; };
 		961C4163260882B9001D8467 /* APITokenManagable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APITokenManagable.swift; sourceTree = "<group>"; };
 		961C4165260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthRefreshOrWaitActionGenerator.swift; sourceTree = "<group>"; };
@@ -820,6 +822,14 @@
 			path = Repository;
 			sourceTree = "<group>";
 		};
+		961C1CDB2685F84B00BE6F3B /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				961C1CDC2685F86200BE6F3B /* String+ISO8601Date.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		961C415F26088298001D8467 /* Core */ = {
 			isa = PBXGroup;
 			children = (
@@ -927,13 +937,14 @@
 			isa = PBXGroup;
 			children = (
 				961C41AB260882BA001D8467 /* schema.json */,
+				961C4189260882BA001D8467 /* GraphNetworkCachePolicy.swift */,
 				9606EDA8267B7CE800ED24D0 /* GraphQLFactory.swift */,
 				9606EDAA267B7CF900ED24D0 /* GraphQLManager.swift */,
-				961C4189260882BA001D8467 /* GraphNetworkCachePolicy.swift */,
 				964A3BF02680B94E00C42C35 /* GraphQLManagerError.swift */,
 				961C419B260882BA001D8467 /* API */,
 				9606EDAC267B7EA200ED24D0 /* Interceptors */,
 				961C1C86268202A600BE6F3B /* Tests */,
+				961C1CDB2685F84B00BE6F3B /* Utils */,
 			);
 			path = GraphQL;
 			sourceTree = "<group>";
@@ -1495,7 +1506,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "SCRIPT_PATH=\"${PODS_ROOT}/Apollo/scripts\"\nGRAPHQL_PATH=\"${SRCROOT}/Core/GraphQL\"\ncd $GRAPHQL_PATH\n\"${SCRIPT_PATH}\"/run-bundled-codegen.sh schema:download --endpoint=\"https://staging-graphql-eu.realifetech.com\" --header=\"Authorization: Bearer NGZjZjViZDE2YTk5MjU1YzJlMzk3MDYxYzhmZjc4MzBlMDQxYzg2MjYwMTNmYTAwY2IyMzI4NzlkNWI3YzEzNw\"\n\"${SCRIPT_PATH}\"/run-bundled-codegen.sh codegen:generate --target=swift --namespace=\"ApolloType\" --includes=${GRAPHQL_PATH}/GraphQLFiles/*.graphql --localSchemaFile=\"${GRAPHQL_PATH}/schema.json\" API/\n";
+			shellScript = "SCRIPT_PATH=\"${PODS_ROOT}/Apollo/scripts\"\nGRAPHQL_PATH=\"${SRCROOT}/Core/GraphQL\"\ncd $GRAPHQL_PATH\n#\"${SCRIPT_PATH}\"/run-bundled-codegen.sh schema:download --endpoint=\"https://staging-graphql-eu.realifetech.com\" --header=\"Authorization: Bearer NGZjZjViZDE2YTk5MjU1YzJlMzk3MDYxYzhmZjc4MzBlMDQxYzg2MjYwMTNmYTAwY2IyMzI4NzlkNWI3YzEzNw\"\n\"${SCRIPT_PATH}\"/run-bundled-codegen.sh codegen:generate --target=swift --namespace=\"ApolloType\" --includes=${GRAPHQL_PATH}/GraphQLFiles/*.graphql --localSchemaFile=\"${GRAPHQL_PATH}/schema.json\" API/\n";
 		};
 		C727D3220B094BF8B35EE985 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1608,6 +1619,7 @@
 				9606ED9B267B651800ED24D0 /* ProductRepository.swift in Sources */,
 				961C1CBB26839C2500BE6F3B /* BasketItem.swift in Sources */,
 				480BCD95251E254D00266617 /* RealifeTech.swift in Sources */,
+				961C1CDD2685F86200BE6F3B /* String+ISO8601Date.swift in Sources */,
 				0319F3362667995B00C01E1F /* canvas_fragment_widget.graphql.swift in Sources */,
 				0319F3332667995B00C01E1F /* sell_fragment_form.graphql.swift in Sources */,
 				961C4269260882C8001D8467 /* QueueItem.swift in Sources */,

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		961C1CA72683405400BE6F3B /* ProductVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CA62683405400BE6F3B /* ProductVariant.swift */; };
 		961C1CA92683407B00BE6F3B /* ProductCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CA82683407B00BE6F3B /* ProductCategory.swift */; };
 		961C1CAB2683409C00BE6F3B /* StandardDescriptionTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CAA2683409C00BE6F3B /* StandardDescriptionTranslation.swift */; };
+		961C1CB0268396F100BE6F3B /* sell_getMyBasket.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CAF268396F100BE6F3B /* sell_getMyBasket.graphql.swift */; };
 		961C41CE260882BA001D8467 /* APITokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4162260882B9001D8467 /* APITokenManager.swift */; };
 		961C41CF260882BA001D8467 /* APITokenManagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4163260882B9001D8467 /* APITokenManagable.swift */; };
 		961C41D0260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4165260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift */; };
@@ -340,6 +341,7 @@
 		961C1CA62683405400BE6F3B /* ProductVariant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariant.swift; sourceTree = "<group>"; };
 		961C1CA82683407B00BE6F3B /* ProductCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategory.swift; sourceTree = "<group>"; };
 		961C1CAA2683409C00BE6F3B /* StandardDescriptionTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardDescriptionTranslation.swift; sourceTree = "<group>"; };
+		961C1CAF268396F100BE6F3B /* sell_getMyBasket.graphql.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = sell_getMyBasket.graphql.swift; sourceTree = "<group>"; };
 		961C4162260882B9001D8467 /* APITokenManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APITokenManager.swift; sourceTree = "<group>"; };
 		961C4163260882B9001D8467 /* APITokenManagable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APITokenManagable.swift; sourceTree = "<group>"; };
 		961C4165260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthRefreshOrWaitActionGenerator.swift; sourceTree = "<group>"; };
@@ -910,6 +912,7 @@
 				0319F3072667995B00C01E1F /* sell_getFulfilmentPointCategories.graphql.swift */,
 				0319F3082667995B00C01E1F /* sell_getFulfilmentPointCategoryById.graphql.swift */,
 				0319F3022667995B00C01E1F /* sell_getFulfilmentPoints.graphql.swift */,
+				961C1CAF268396F100BE6F3B /* sell_getMyBasket.graphql.swift */,
 				0319F2EE2667995A00C01E1F /* sell_getMyPaymentSources.graphql.swift */,
 				0319F30A2667995B00C01E1F /* sell_getOrders.graphql.swift */,
 				0319F2F62667995A00C01E1F /* sell_getProductById.graphql.swift */,
@@ -1566,6 +1569,7 @@
 				48EFE24B2539E52D00CC6E58 /* General.swift in Sources */,
 				0319F3142667995B00C01E1F /* sell_addPaymentSourceToMyWallet.graphql.swift in Sources */,
 				0319F31F2667995B00C01E1F /* sell_fragment_paymentSourceDetails.graphql.swift in Sources */,
+				961C1CB0268396F100BE6F3B /* sell_getMyBasket.graphql.swift in Sources */,
 				0319F3292667995B00C01E1F /* sell_fragment_order.graphql.swift in Sources */,
 				961C4275260882C8001D8467 /* ReachabilityChecker.swift in Sources */,
 				961C426D260882C8001D8467 /* DeviceRepository.swift in Sources */,

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -109,6 +109,10 @@
 		961C1CA92683407B00BE6F3B /* ProductCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CA82683407B00BE6F3B /* ProductCategory.swift */; };
 		961C1CAB2683409C00BE6F3B /* StandardDescriptionTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CAA2683409C00BE6F3B /* StandardDescriptionTranslation.swift */; };
 		961C1CB0268396F100BE6F3B /* sell_getMyBasket.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CAF268396F100BE6F3B /* sell_getMyBasket.graphql.swift */; };
+		961C1CB526839A5100BE6F3B /* Basket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CB426839A5100BE6F3B /* Basket.swift */; };
+		961C1CB726839AE100BE6F3B /* CollectionPreferenceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CB626839AE100BE6F3B /* CollectionPreferenceType.swift */; };
+		961C1CBB26839C2500BE6F3B /* BasketItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CBA26839C2500BE6F3B /* BasketItem.swift */; };
+		961C1CBD26839C3700BE6F3B /* SeatInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C1CBC26839C3700BE6F3B /* SeatInfo.swift */; };
 		961C41CE260882BA001D8467 /* APITokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4162260882B9001D8467 /* APITokenManager.swift */; };
 		961C41CF260882BA001D8467 /* APITokenManagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4163260882B9001D8467 /* APITokenManagable.swift */; };
 		961C41D0260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961C4165260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift */; };
@@ -342,6 +346,10 @@
 		961C1CA82683407B00BE6F3B /* ProductCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategory.swift; sourceTree = "<group>"; };
 		961C1CAA2683409C00BE6F3B /* StandardDescriptionTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardDescriptionTranslation.swift; sourceTree = "<group>"; };
 		961C1CAF268396F100BE6F3B /* sell_getMyBasket.graphql.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = sell_getMyBasket.graphql.swift; sourceTree = "<group>"; };
+		961C1CB426839A5100BE6F3B /* Basket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Basket.swift; sourceTree = "<group>"; };
+		961C1CB626839AE100BE6F3B /* CollectionPreferenceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionPreferenceType.swift; sourceTree = "<group>"; };
+		961C1CBA26839C2500BE6F3B /* BasketItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasketItem.swift; sourceTree = "<group>"; };
+		961C1CBC26839C3700BE6F3B /* SeatInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeatInfo.swift; sourceTree = "<group>"; };
 		961C4162260882B9001D8467 /* APITokenManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APITokenManager.swift; sourceTree = "<group>"; };
 		961C4163260882B9001D8467 /* APITokenManagable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APITokenManagable.swift; sourceTree = "<group>"; };
 		961C4165260882BA001D8467 /* OAuthRefreshOrWaitActionGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthRefreshOrWaitActionGenerator.swift; sourceTree = "<group>"; };
@@ -675,6 +683,7 @@
 				9606ED80267B4FE400ED24D0 /* Sell.swift */,
 				9606ED98267B64B600ED24D0 /* SellFactory.swift */,
 				9606ED96267B646F00ED24D0 /* SellImplementing.swift */,
+				961C1CB12683982C00BE6F3B /* Basket */,
 				964A3BE22680AA4A00C42C35 /* FulfilmentPoint */,
 				9606ED82267B4FEC00ED24D0 /* Product */,
 				964A3BE92680AC3F00C42C35 /* Utils */,
@@ -758,6 +767,33 @@
 				961C1C9C2682436B00BE6F3B /* FulfilmentPointRepositoryTests.swift */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		961C1CB12683982C00BE6F3B /* Basket */ = {
+			isa = PBXGroup;
+			children = (
+				961C1CB226839A3A00BE6F3B /* Models */,
+				961C1CB326839A4200BE6F3B /* Repository */,
+			);
+			path = Basket;
+			sourceTree = "<group>";
+		};
+		961C1CB226839A3A00BE6F3B /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				961C1CB426839A5100BE6F3B /* Basket.swift */,
+				961C1CBA26839C2500BE6F3B /* BasketItem.swift */,
+				961C1CB626839AE100BE6F3B /* CollectionPreferenceType.swift */,
+				961C1CBC26839C3700BE6F3B /* SeatInfo.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		961C1CB326839A4200BE6F3B /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Repository;
 			sourceTree = "<group>";
 		};
 		961C415F26088298001D8467 /* Core */ = {
@@ -1544,6 +1580,7 @@
 				961C4215260882BB001D8467 /* DiskCache.swift in Sources */,
 				961C4268260882C8001D8467 /* PersistentQueue.swift in Sources */,
 				9606ED9B267B651800ED24D0 /* ProductRepository.swift in Sources */,
+				961C1CBB26839C2500BE6F3B /* BasketItem.swift in Sources */,
 				480BCD95251E254D00266617 /* RealifeTech.swift in Sources */,
 				0319F3362667995B00C01E1F /* canvas_fragment_widget.graphql.swift in Sources */,
 				0319F3332667995B00C01E1F /* sell_fragment_form.graphql.swift in Sources */,
@@ -1617,6 +1654,7 @@
 				0319F3132667995B00C01E1F /* sell_createPaymentIntent.graphql.swift in Sources */,
 				0319F31E2667995B00C01E1F /* sell_getProductById.graphql.swift in Sources */,
 				9606EDA9267B7CE800ED24D0 /* GraphQLFactory.swift in Sources */,
+				961C1CBD26839C3700BE6F3B /* SeatInfo.swift in Sources */,
 				968CA5DB25EE7C410000C2E2 /* ContentImplementing.swift in Sources */,
 				0319F3152667995B00C01E1F /* sell_fragment_user.graphql.swift in Sources */,
 				0319F3212667995B00C01E1F /* sell_updatePaymentIntent.graphql.swift in Sources */,
@@ -1633,6 +1671,7 @@
 				961C4217260882BB001D8467 /* APIError.swift in Sources */,
 				0319F3242667995B00C01E1F /* sell_fragment_venue.graphql.swift in Sources */,
 				487479BE2540423D0048F03D /* AnalyticsLogger.swift in Sources */,
+				961C1CB526839A5100BE6F3B /* Basket.swift in Sources */,
 				961C4260260882C8001D8467 /* DiskStorage.swift in Sources */,
 				968CA5D525EE7BEC0000C2E2 /* WebPageCreatable.swift in Sources */,
 				0319F3272667995B00C01E1F /* audience_fetchBelongsToAudienceWithExternalId.graphql.swift in Sources */,
@@ -1643,6 +1682,7 @@
 				0319F3182667995B00C01E1F /* sell_checkoutMyBasket.graphql.swift in Sources */,
 				961C1CA92683407B00BE6F3B /* ProductCategory.swift in Sources */,
 				961C4224260882BB001D8467 /* RequestLogger.swift in Sources */,
+				961C1CB726839AE100BE6F3B /* CollectionPreferenceType.swift in Sources */,
 				0319F32D2667995B00C01E1F /* sell_fragment_timeslot.graphql.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sell/Basket/Models/Basket.swift
+++ b/Sell/Basket/Models/Basket.swift
@@ -1,0 +1,21 @@
+//
+//  Basket.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 23/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public struct Basket {
+
+    public let grossAmount: Int?
+    public let discountAmount: Int?
+    public let netAmount: Int?
+    public let seatInfo: [SeatInfo]?
+    public let timeslot: Timeslot?
+    public let collectionDate: Date?
+    public let collectionPreferenceType: CollectionPreferenceType?
+    public let items: [BasketItem]?
+}

--- a/Sell/Basket/Models/Basket.swift
+++ b/Sell/Basket/Models/Basket.swift
@@ -15,7 +15,7 @@ public struct Basket {
     public let netAmount: Int?
     public let seatInfo: [SeatInfo]?
     public let timeslot: Timeslot?
-    public let collectionDate: String?
+    public let collectionDate: Date?
     public let collectionPreferenceType: CollectionPreferenceType?
     public let items: [BasketItem]?
 
@@ -27,7 +27,7 @@ public struct Basket {
             SeatInfo(key: $0?.key, value: $0?.value)
         }
         timeslot = Timeslot(response: response.timeslot?.fragments.fragmentTimeslot)
-        collectionDate = response.collectionDate
+        collectionDate = response.collectionDate?.iso8601Date
         collectionPreferenceType = CollectionPreferenceType(rawValue: response.collectionPreferenceType ?? "")
         items = response.items?.compactMap {
             BasketItem(response: $0)

--- a/Sell/Basket/Models/Basket.swift
+++ b/Sell/Basket/Models/Basket.swift
@@ -15,7 +15,22 @@ public struct Basket {
     public let netAmount: Int?
     public let seatInfo: [SeatInfo]?
     public let timeslot: Timeslot?
-    public let collectionDate: Date?
+    public let collectionDate: String?
     public let collectionPreferenceType: CollectionPreferenceType?
     public let items: [BasketItem]?
+
+    init(response: ApolloType.FragmentBasket) {
+        grossAmount = response.grossAmount
+        discountAmount = response.discountAmount
+        netAmount = response.netAmount
+        seatInfo = response.seatInfo?.compactMap {
+            SeatInfo(key: $0?.key, value: $0?.value)
+        }
+        timeslot = Timeslot(response: response.timeslot?.fragments.fragmentTimeslot)
+        collectionDate = response.collectionDate
+        collectionPreferenceType = CollectionPreferenceType(rawValue: response.collectionPreferenceType ?? "")
+        items = response.items?.compactMap {
+            BasketItem(response: $0)
+        }
+    }
 }

--- a/Sell/Basket/Models/BasketInput.swift
+++ b/Sell/Basket/Models/BasketInput.swift
@@ -1,0 +1,19 @@
+//
+//  BasketInput.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 23/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public struct BasketInput {
+
+    public let collectionDate: String?
+    public let collectionPreferenceType: CollectionPreferenceType?
+    public let timeslotId: String?
+    public let fulfilmentPointId: String?
+    public let seatInfo: [SeatInfo]?
+    public let items: [BasketItemInput]?
+}

--- a/Sell/Basket/Models/BasketInput.swift
+++ b/Sell/Basket/Models/BasketInput.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct BasketInput {
 
-    public let collectionDate: String?
+    public let collectionDate: Date?
     public let collectionPreferenceType: CollectionPreferenceType?
     public let timeslotId: String?
     public let fulfilmentPointId: String?

--- a/Sell/Basket/Models/BasketItem.swift
+++ b/Sell/Basket/Models/BasketItem.swift
@@ -18,5 +18,20 @@ public struct BasketItem {
     public let fulfilmentPoint: FulfilmentPoint?
     public let productVariant: ProductVariant?
     public let product: Product?
-    public let productModifierItems: [ProductModifierItem]?
+    public let productModifierItems: [ProductModifierItemSelection]?
+
+    init?(response: ApolloType.FragmentBasket.Item?) {
+        guard let response = response else { return nil }
+        id = response.id
+        price = response.price
+        modifierItemsPrice = response.modifierItemsPrice
+        quantity = response.quantity
+        totalPrice = response.totalPrice
+        fulfilmentPoint = FulfilmentPoint(response: response.fulfilmentPoint?.fragments.fragmentFulfilmentPoint)
+        productVariant = ProductVariant(response: response.productVariant?.fragments.fragmentProductVariant)
+        product = Product(response: response.product?.fragments.fragmentProduct)
+        productModifierItems = response.productModifierItems?.compactMap {
+            ProductModifierItemSelection(response: $0?.fragments.fragmentProductModifierItemSelection)
+        }
+    }
 }

--- a/Sell/Basket/Models/BasketItem.swift
+++ b/Sell/Basket/Models/BasketItem.swift
@@ -1,0 +1,22 @@
+//
+//  BasketItem.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 23/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public struct BasketItem {
+
+    public let id: String
+    public let price: Int?
+    public let modifierItemsPrice: Int?
+    public let quantity: Int?
+    public let totalPrice: Int?
+    public let fulfilmentPoint: FulfilmentPoint?
+    public let productVariant: ProductVariant?
+    public let product: Product?
+    public let productModifierItems: [ProductModifierItem]?
+}

--- a/Sell/Basket/Models/BasketItemInput.swift
+++ b/Sell/Basket/Models/BasketItemInput.swift
@@ -1,0 +1,18 @@
+//
+//  BasketItemInput.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 24/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public struct BasketItemInput {
+
+    public let productId: String?
+    public let productVariantId: String?
+    public let fulfilmentPointId: String?
+    public let quantity: Int?
+    public let productModifierItems: [ProductModifierItemSelectionInput]?
+}

--- a/Sell/Basket/Models/CheckoutInput.swift
+++ b/Sell/Basket/Models/CheckoutInput.swift
@@ -1,0 +1,15 @@
+//
+//  CheckoutInput.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 24/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public struct CheckoutInput {
+
+    public let netAmount: Int?
+    public let language: String?
+}

--- a/Sell/Basket/Models/CollectionPreferenceType.swift
+++ b/Sell/Basket/Models/CollectionPreferenceType.swift
@@ -1,0 +1,15 @@
+//
+//  CollectionPreferenceType.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 23/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public enum CollectionPreferenceType: String, Codable {
+    case asap = "ASAP"
+    case preorder = "PREORDER"
+    case checkin = "CHECKIN"
+}

--- a/Sell/Basket/Models/ProductModifierItemSelection.swift
+++ b/Sell/Basket/Models/ProductModifierItemSelection.swift
@@ -1,0 +1,26 @@
+//
+//  ProductModifierItemSelection.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 24/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public struct ProductModifierItemSelection {
+
+    public let productModifierItem: ProductModifierItem?
+    public let quantity: Int?
+    public let totalPrice: Int?
+
+    init(response: ApolloType.FragmentProductModifierItemSelection?) {
+        productModifierItem = ProductModifierItem(
+            response: response?
+                .productModifierItem?
+                .fragments
+                .fragmentProductModifierItem)
+        quantity = response?.quantity
+        totalPrice = response?.totalPrice
+    }
+}

--- a/Sell/Basket/Models/SeatInfo.swift
+++ b/Sell/Basket/Models/SeatInfo.swift
@@ -10,6 +10,11 @@ import Foundation
 
 public struct SeatInfo {
 
-    public let key: String
+    public let key: String?
     public let value: String?
+
+    init(key: String?, value: String?) {
+        self.key = key
+        self.value = value
+    }
 }

--- a/Sell/Basket/Models/SeatInfo.swift
+++ b/Sell/Basket/Models/SeatInfo.swift
@@ -1,0 +1,15 @@
+//
+//  SeatInfo.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 23/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public struct SeatInfo {
+
+    public let key: String
+    public let value: String?
+}

--- a/Sell/Basket/Repository/BasketError.swift
+++ b/Sell/Basket/Repository/BasketError.swift
@@ -14,12 +14,12 @@ public enum BasketError: Error, LocalizedError {
     case priceChange
     case mixedBasket
     case emptyBasket
-    case regularErrors([Error])
+    case regularError(Error)
 
     public var errorDescription: String? {
         switch self {
-        case .regularErrors(let errors):
-            return errors.compactMap { $0.localizedDescription }.joined(separator: "\n")
+        case .regularError(let error):
+            return error.localizedDescription
         default:
             return localizedDescription
         }

--- a/Sell/Basket/Repository/BasketError.swift
+++ b/Sell/Basket/Repository/BasketError.swift
@@ -1,0 +1,27 @@
+//
+//  BasketError.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 24/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public enum BasketError: Error, LocalizedError {
+
+    case outOfStock
+    case priceChange
+    case mixedBasket
+    case emptyBasket
+    case regularErrors([Error])
+
+    public var errorDescription: String? {
+        switch self {
+        case .regularErrors(let errors):
+            return errors.compactMap { $0.localizedDescription }.joined(separator: "\n")
+        default:
+            return localizedDescription
+        }
+    }
+}

--- a/Sell/Basket/Repository/BasketProvidable.swift
+++ b/Sell/Basket/Repository/BasketProvidable.swift
@@ -1,0 +1,33 @@
+//
+//  BasketProvidable.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 23/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public protocol BasketProvidable {
+
+    func getMyBasket(
+        callback: @escaping (Result<Basket, BasketError>) -> Void)
+
+    func createMyBasket(
+        input: BasketInput,
+        callback: @escaping (Result<Basket, BasketError>) -> Void)
+
+    func updateMyBasket(
+        input: BasketInput,
+        callback: @escaping (Result<Basket, BasketError>) -> Void)
+
+    func deleteMyBasket(
+        callback: @escaping (Result<Bool, BasketError>) -> Void)
+
+    func checkoutMyBasket(
+        input: CheckoutInput,
+        callback: @escaping (Result<Order, BasketError>) -> Void)
+}
+
+// TODO: ID-1027
+public struct Order { }

--- a/Sell/Basket/Repository/BasketRepository.swift
+++ b/Sell/Basket/Repository/BasketRepository.swift
@@ -1,0 +1,183 @@
+//
+//  BasketRepository.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 23/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+import Apollo
+
+public final class BasketRepository {
+
+    private let graphQLManager: GraphQLManageable
+
+    init(graphQLManager: GraphQLManageable) {
+        self.graphQLManager = graphQLManager
+    }
+
+    private func transformErrorIfNeccessary(_ errors: [GraphQLError]?) -> BasketError? {
+        guard let errors = errors else { return nil }
+        for error in errors {
+            switch error.extensions?["code"] as? String {
+            case "SELL_BASKET_OUT_OF_STOCK":
+                return .outOfStock
+            case "SELL_BASKET_PRICE_CHANGE":
+                return .priceChange
+            case "SELL_BASKET_MIXED":
+                return .mixedBasket
+            case "SELL_BASKET_EMPTY":
+                return .emptyBasket
+            default:
+                continue
+            }
+        }
+        return .regularErrors(errors)
+    }
+
+    private func makeApolloBasketInput(_ input: BasketInput) -> ApolloType.BasketInput {
+        ApolloType.BasketInput(
+            collectionDate: input.collectionDate,
+            collectionPreferenceType: input.collectionPreferenceType?.rawValue,
+            timeslot: input.timeslotId,
+            fulfilmentPoint: input.fulfilmentPointId,
+            seatInfo: input.seatInfo?.compactMap {
+                ApolloType.SeatInfoInput(key: $0.key, value: $0.value)
+            },
+            items: input.items?.compactMap {
+                ApolloType.BasketItemInput(
+                    product: $0.productId,
+                    productVariant: $0.productVariantId,
+                    fulfilmentPoint: $0.fulfilmentPointId,
+                    quantity: $0.quantity,
+                    productModifierItems: $0.productModifierItems?.compactMap {
+                        ApolloType.ProductModifierItemSelectionInput(
+                            productModifierItemId: $0.productModifierItemId,
+                            quantity: $0.quantity)
+                    }
+                )
+            }
+        )
+    }
+
+    private func makeApolloCheckoutInput(_ input: CheckoutInput) -> ApolloType.CheckoutInput {
+        ApolloType.CheckoutInput(
+            netAmount: input.netAmount,
+            language: ApolloType.Language(rawValue: input.language ?? ""))
+    }
+}
+
+extension BasketRepository: BasketProvidable {
+
+    public func getMyBasket(
+        callback: @escaping (Result<Basket, BasketError>) -> Void
+    ) {
+        graphQLManager.dispatch(
+            query: ApolloType.GetMyBasketQuery(),
+            cachePolicy: .fetchIgnoringCacheCompletely) { result in
+            switch result {
+            case .success(let response):
+                if let transformedError = self.transformErrorIfNeccessary(response.errors) {
+                    callback(.failure(transformedError))
+                } else if let returnedBasket = response.data?.getMyBasket?.fragments.fragmentBasket {
+                    callback(.success(Basket(response: returnedBasket)))
+                } else {
+                    callback(.failure(.emptyBasket))
+                }
+            case .failure(let error):
+                callback(.failure(.regularErrors([error])))
+            }
+        }
+    }
+
+    public func createMyBasket(
+        input: BasketInput,
+        callback: @escaping (Result<Basket, BasketError>) -> Void
+    ) {
+        graphQLManager.dispatchMutation(
+            mutation: ApolloType.CreateMyBasketMutation(input: makeApolloBasketInput(input)),
+            cacheResultToPersistence: false
+        ) { result in
+            switch result {
+            case .success(let response):
+                if let transformedError = self.transformErrorIfNeccessary(response.errors) {
+                    callback(.failure(transformedError))
+                } else if let returnedBasket = response.data?.createMyBasket?.fragments.fragmentBasket {
+                    callback(.success(Basket(response: returnedBasket)))
+                } else {
+                    callback(.failure(.emptyBasket))
+                }
+            case .failure(let error):
+                callback(.failure(.regularErrors([error])))
+            }
+        }
+    }
+
+    public func updateMyBasket(
+        input: BasketInput,
+        callback: @escaping (Result<Basket, BasketError>) -> Void
+    ) {
+        graphQLManager.dispatchMutation(
+            mutation: ApolloType.UpdateMyBasketMutation(input: makeApolloBasketInput(input)),
+            cacheResultToPersistence: false
+        ) { result in
+            switch result {
+            case .success(let response):
+                if let transformedError = self.transformErrorIfNeccessary(response.errors) {
+                    callback(.failure(transformedError))
+                } else if let returnedBasket = response.data?.updateMyBasket?.fragments.fragmentBasket {
+                    callback(.success(Basket(response: returnedBasket)))
+                } else {
+                    callback(.failure(.emptyBasket))
+                }
+            case .failure(let error):
+                callback(.failure(.regularErrors([error])))
+            }
+        }
+    }
+
+    public func deleteMyBasket(
+        callback: @escaping (Result<Bool, BasketError>) -> Void
+    ) {
+        graphQLManager.dispatchMutation(
+            mutation: ApolloType.DeleteMyBasketMutation(),
+            cacheResultToPersistence: false
+        ) { result in
+            switch result {
+            case .success(let response):
+                if let transformedError = self.transformErrorIfNeccessary(response.errors) {
+                    callback(.failure(transformedError))
+                } else {
+                    callback(.success(response.data?.deleteMyBasket?.success ?? false))
+                }
+            case .failure(let error):
+                callback(.failure(.regularErrors([error])))
+            }
+        }
+    }
+
+    public func checkoutMyBasket(
+        input: CheckoutInput,
+        callback: @escaping (Result<Order, BasketError>) -> Void
+    ) {
+        graphQLManager.dispatchMutation(
+            mutation: ApolloType.CheckoutMyBasketMutation(input: makeApolloCheckoutInput(input)),
+            cacheResultToPersistence: false
+        ) { result in
+            switch result {
+            case .success(let response):
+                if let transformedError = self.transformErrorIfNeccessary(response.errors) {
+                    callback(.failure(transformedError))
+                } else if let _ = response.data?.checkoutMyBasket?.fragments.fragmentOrder {
+                    // TODO: ID-1027
+                    callback(.success(Order()))
+                } else {
+                    callback(.failure(.emptyBasket))
+                }
+            case .failure(let error):
+                callback(.failure(.regularErrors([error])))
+            }
+        }
+    }
+}

--- a/Sell/Basket/Repository/BasketRepository.swift
+++ b/Sell/Basket/Repository/BasketRepository.swift
@@ -33,12 +33,12 @@ public final class BasketRepository {
                 continue
             }
         }
-        return .regularErrors(errors)
+        return nil
     }
 
     private func makeApolloBasketInput(_ input: BasketInput) -> ApolloType.BasketInput {
         ApolloType.BasketInput(
-            collectionDate: input.collectionDate,
+            collectionDate: input.collectionDate?.iso8601String,
             collectionPreferenceType: input.collectionPreferenceType?.rawValue,
             timeslot: input.timeslotId,
             fulfilmentPoint: input.fulfilmentPointId,
@@ -83,10 +83,10 @@ extension BasketRepository: BasketProvidable {
                 } else if let returnedBasket = response.data?.getMyBasket?.fragments.fragmentBasket {
                     callback(.success(Basket(response: returnedBasket)))
                 } else {
-                    callback(.failure(.emptyBasket))
+                    callback(.failure(.regularError(GraphQLManagerError.noDataError)))
                 }
             case .failure(let error):
-                callback(.failure(.regularErrors([error])))
+                callback(.failure(.regularError(error)))
             }
         }
     }
@@ -106,10 +106,10 @@ extension BasketRepository: BasketProvidable {
                 } else if let returnedBasket = response.data?.createMyBasket?.fragments.fragmentBasket {
                     callback(.success(Basket(response: returnedBasket)))
                 } else {
-                    callback(.failure(.emptyBasket))
+                    callback(.failure(.regularError(GraphQLManagerError.noDataError)))
                 }
             case .failure(let error):
-                callback(.failure(.regularErrors([error])))
+                callback(.failure(.regularError(error)))
             }
         }
     }
@@ -129,10 +129,10 @@ extension BasketRepository: BasketProvidable {
                 } else if let returnedBasket = response.data?.updateMyBasket?.fragments.fragmentBasket {
                     callback(.success(Basket(response: returnedBasket)))
                 } else {
-                    callback(.failure(.emptyBasket))
+                    callback(.failure(.regularError(GraphQLManagerError.noDataError)))
                 }
             case .failure(let error):
-                callback(.failure(.regularErrors([error])))
+                callback(.failure(.regularError(error)))
             }
         }
     }
@@ -152,7 +152,7 @@ extension BasketRepository: BasketProvidable {
                     callback(.success(response.data?.deleteMyBasket?.success ?? false))
                 }
             case .failure(let error):
-                callback(.failure(.regularErrors([error])))
+                callback(.failure(.regularError(error)))
             }
         }
     }
@@ -173,10 +173,10 @@ extension BasketRepository: BasketProvidable {
                     // TODO: ID-1027
                     callback(.success(Order()))
                 } else {
-                    callback(.failure(.emptyBasket))
+                    callback(.failure(.regularError(GraphQLManagerError.noDataError)))
                 }
             case .failure(let error):
-                callback(.failure(.regularErrors([error])))
+                callback(.failure(.regularError(error)))
             }
         }
     }

--- a/Sell/Product/Models/ProductModifierItemSelectionInput.swift
+++ b/Sell/Product/Models/ProductModifierItemSelectionInput.swift
@@ -1,0 +1,15 @@
+//
+//  ProductModifierItemSelectionInput.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 24/06/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+public struct ProductModifierItemSelectionInput {
+
+    public let productModifierItemId: String?
+    public let quantity: Int?
+}

--- a/Sell/Sell.swift
+++ b/Sell/Sell.swift
@@ -10,5 +10,6 @@ import Foundation
 
 public protocol Sell {
     var product: ProductProvidable { get }
+    var basket: BasketProvidable { get }
     var fulfilmentPoint: FulfilmentPointProvidable { get }
 }

--- a/Sell/SellFactory.swift
+++ b/Sell/SellFactory.swift
@@ -13,6 +13,7 @@ public enum SellFactory {
     static func makeSellModule(graphQLManager: GraphQLManageable) -> Sell {
         return SellImplementing(
             product: ProductRepository(graphQLManager: graphQLManager),
+            basket: BasketRepository(graphQLManager: graphQLManager),
             fulfilmentPoint: FulfilmentPointRepository(graphQLManager: graphQLManager))
     }
 }

--- a/Sell/SellImplementing.swift
+++ b/Sell/SellImplementing.swift
@@ -11,13 +11,16 @@ import Foundation
 public class SellImplementing: Sell {
 
     public let product: ProductProvidable
+    public let basket: BasketProvidable
     public let fulfilmentPoint: FulfilmentPointProvidable
 
     public init(
         product: ProductProvidable,
+        basket: BasketProvidable,
         fulfilmentPoint: FulfilmentPointProvidable
     ) {
         self.product = product
+        self.basket = basket
         self.fulfilmentPoint = fulfilmentPoint
     }
 }

--- a/Sell/Tests/SellFactoryTests.swift
+++ b/Sell/Tests/SellFactoryTests.swift
@@ -17,6 +17,7 @@ final class SellFactoryTests: XCTestCase {
         let result = SellFactory.makeSellModule(graphQLManager: graphQLManager)
         XCTAssertTrue(result is SellImplementing)
         XCTAssertTrue(result.product is ProductRepository)
+        XCTAssertTrue(result.basket is BasketRepository)
         XCTAssertTrue(result.fulfilmentPoint is FulfilmentPointRepository)
     }
 }


### PR DESCRIPTION
The cache policy for the Apollo mutation is like this on the Apollo SDK, so I add a new boolean `cacheResultToPersistence` to the GraphQLManageable to let developers have control of caching policy.
```
cachePolicy: publishResultToStore ? .default : .fetchIgnoringCacheCompletely,
```

The basket error is handled in the enum `BasketError` as the mutations return us `Error` for these cases.

This PR also implements the basket query and mutations on the repository layer.