### PR TITLE
ID-1149 Add the StandardSenderResponse decoding type to display correct message

### DIFF
--- a/Core/APILayer/Tests/Util/APIErrorTests.swift
+++ b/Core/APILayer/Tests/Util/APIErrorTests.swift
@@ -14,13 +14,20 @@ final class APIErrorTests: XCTestCase {
     let errorData = ["error": "invalid_grant", "error_description": "The access token provided has expired."]
     let mockError = MockAPIError.genericError()
 
-    func test_constructedError_from_ValidData() throws {
+    func test_constructedError_fromValidData() throws {
         let basicErrorData = try JSONEncoder().encode(errorData)
         let constructedError = APIError.constructedError(data: basicErrorData)
         XCTAssertEqual(constructedError.message, "The access token provided has expired.")
     }
 
-    func test_constructedError_from_InvalidData() throws {
+    func test_constructedError_fromStandardSenderResponseData() throws {
+        let response = StandardSenderResponse(code: 400, type: "", message: "Not found")
+        let data = try JSONEncoder().encode(response)
+        let constructedError = APIError.constructedError(data: data)
+        XCTAssertEqual(constructedError.message, response.message)
+    }
+
+    func test_constructedError_fromInvalidData() throws {
         let errorData = "{\"error\":\"invalid_grant\",\"error_description\":\"The access token provided has expired.\"}"
         let basicErrorData = try JSONEncoder().encode(errorData)
         let constructedError = APIError.constructedError(data: basicErrorData)

--- a/Core/APILayer/Util/APIError.swift
+++ b/Core/APILayer/Util/APIError.swift
@@ -69,11 +69,14 @@ public final class APIError: Error {
         let error = APIError()
         error.data = data
         error.statusCode = statusCode
-        do {
-            let response = try JSONDecoder().decode(StandardSenderResponse.self, from: data)
+        if let decodedError = try? JSONDecoder().decode([String: String].self, from: data) {
+            let message = decodedError["message"] ?? decodedError["error_description"]
+            error.title = nil
+            error.message = message
+        } else if let response = try? JSONDecoder().decode(StandardSenderResponse.self, from: data) {
             error.title = nil
             error.message = response.message
-        } catch _ {
+        } else {
             error.title = "ERROR".coreLocalizedString
             error.message = "UNPARSEABLE_ERROR".coreLocalizedString
         }

--- a/Core/APILayer/Util/APIError.swift
+++ b/Core/APILayer/Util/APIError.swift
@@ -70,10 +70,9 @@ public final class APIError: Error {
         error.data = data
         error.statusCode = statusCode
         do {
-            let errorDictionary = try JSONDecoder().decode([String: String].self, from: data)
-            let message = errorDictionary["message"] ?? errorDictionary["error_description"]
+            let response = try JSONDecoder().decode(StandardSenderResponse.self, from: data)
             error.title = nil
-            error.message = message
+            error.message = response.message
         } catch _ {
             error.title = "ERROR".coreLocalizedString
             error.message = "UNPARSEABLE_ERROR".coreLocalizedString


### PR DESCRIPTION
The previous PR doesn't display the correct message as the decoding type is wrong on `APIError.constructError` function. I added a new decoding type `StandardSenderResponse` to show the correct message that is returned from API calls if the SDK is unable to decode the data to `[String: String]` type.