### PR TITLE
[ID-1187] Add Bluetooth description in info-plist

### DIFF
--- a/RealifeTech-SDK.podspec
+++ b/RealifeTech-SDK.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |spec|
 
   spec.name         = "RealifeTech-SDK"
   spec.module_name  = "RealifeTech"
-  spec.version      = "1.2.6"
+  spec.version      = "1.2.7"
   spec.summary      = "Providing integration with the RealifeTech Experience Automation Platform."
 
   spec.description  = "This is RealifeTech SDK, it provides integration with RealifeTech backend services, providing functionality such as device notification management, audience membership, and analytics logging. Creating a better experience of the real world for every person."

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -1632,7 +1632,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.2.7;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
 				PRODUCT_BUNDLE_IDENTIFIER = com.concertlive.RealifeTech;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1663,7 +1663,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.6;
+				MARKETING_VERSION = 1.2.7;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
 				PRODUCT_BUNDLE_IDENTIFIER = com.concertlive.RealifeTech;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/RealifeTech/Info.plist
+++ b/RealifeTech/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>We use bluetooth to enhance your experience at the arena</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>We need access to this in order to connect to peripherals and to allow greater indoor tracking within the venue/arena</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
The problem is Frontier app doesn't show the Bluetooth permission pop up.
The reason might be because we've moved `BluetoothManagerWrapper` to ios-sdk from Frontier app since version 13.6, and also this problem happened after 13.6

Note: 
After merged, I'll check if this issue can solved and also check if Bluetooth description can be override by Frontier app.

