### PR TITLE
Fixed No such module 'GraphQL' error

### DIFF
--- a/Analytics/AnalyticsLogging/AnalyticsLogger.swift
+++ b/Analytics/AnalyticsLogging/AnalyticsLogger.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 class AnalyticsLogger {
 

--- a/Audiences/AudiencesImplementing.swift
+++ b/Audiences/AudiencesImplementing.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public class AudiencesImplementing: AudienceChecking {
 

--- a/Canvas/Models/ScreenType.swift
+++ b/Canvas/Models/ScreenType.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public enum ScreenType: String {
     case discover

--- a/Canvas/Models/Widget.swift
+++ b/Canvas/Models/Widget.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct Widget: Codable, Equatable {
 

--- a/Canvas/Models/WidgetFetchType.swift
+++ b/Canvas/Models/WidgetFetchType.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public enum WidgetFetchType: String, Codable {
 

--- a/Canvas/Models/WidgetStyle.swift
+++ b/Canvas/Models/WidgetStyle.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct WidgetStyle: Codable, Equatable {
 

--- a/Canvas/Models/WidgetType.swift
+++ b/Canvas/Models/WidgetType.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public enum WidgetType: String, Codable {
     case unknown

--- a/Canvas/Models/WidgetVariation.swift
+++ b/Canvas/Models/WidgetVariation.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct WidgetVariation: Codable, Equatable {
 

--- a/Canvas/Repositories/CanvasRepository.swift
+++ b/Canvas/Repositories/CanvasRepository.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public final class CanvasRepository {
 

--- a/Content/Content.swift
+++ b/Content/Content.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public typealias Content = WebPageCreatable
 public typealias WebPageType = WebPage.`Type`

--- a/Content/ContentImplementing.swift
+++ b/Content/ContentImplementing.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public class ContentImplementing: Content {
 

--- a/DummyProject/DummyProject/AppDelegate.swift
+++ b/DummyProject/DummyProject/AppDelegate.swift
@@ -14,11 +14,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        let configuration = CoreConfiguration(
+        let configuration = SDKConfiguration(
             appCode: "",
             clientSecret: "",
             apiUrl: "",
-            graphQLApiUrl: "")
+            graphQLApiUrlString: "")
         RealifeTech.configureSDK(with: configuration)
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, error in
             if let error = error {

--- a/DummyProject/Podfile
+++ b/DummyProject/Podfile
@@ -1,3 +1,5 @@
+source 'https://github.com/CocoaPods/Specs.git'
+
 platform :ios, '13.0'
 inhibit_all_warnings!
 

--- a/DummyProject/Podfile.lock
+++ b/DummyProject/Podfile.lock
@@ -5,17 +5,11 @@ PODS:
   - Apollo/SQLite (0.40.0):
     - Apollo/Core
     - SQLite.swift (~> 0.12.2)
-  - RealifeTech-SDK (1.2.0):
-    - RealifeTech-SDK/RealifeTech (= 1.2.0)
-    - SwiftLint (~> 0.43.1)
-  - RealifeTech-SDK/Core (1.2.0):
+  - RealifeTech-SDK (1.3.0):
     - Apollo (~> 0.40.0)
     - Apollo/SQLite
     - RxCocoa (~> 6.1.0)
     - RxSwift (~> 6.1.0)
-    - SwiftLint (~> 0.43.1)
-  - RealifeTech-SDK/RealifeTech (1.2.0):
-    - RealifeTech-SDK/Core
     - SwiftLint (~> 0.43.1)
   - RxCocoa (6.1.0):
     - RxRelay (= 6.1.0)
@@ -32,7 +26,7 @@ DEPENDENCIES:
   - RealifeTech-SDK (from `../`)
 
 SPEC REPOS:
-  trunk:
+  https://github.com/CocoaPods/Specs.git:
     - Apollo
     - RxCocoa
     - RxRelay
@@ -46,7 +40,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Apollo: 9fb70b598511a6212a81a34c00fa9bf8bac19a23
-  RealifeTech-SDK: f3bf1a977aaa02a642bca72b736d4ddface6c568
+  RealifeTech-SDK: 339013c2a3f624b9bb674f8f82b043be6d8416f0
   RxCocoa: 5c51f02d562cbd94629f6c26cf0c80fe4ab8d343
   RxRelay: 483e1a19fad961b41f0b0c0bee506f46c1ae14fe
   RxSwift: a834e5c538e89eca0cae86f403f4fbf0336786ce

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3E78BCEE26B8226800BF3026 /* GraphQL.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E78BCEC26B8226800BF3026 /* GraphQL.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3E78BCF226B8231800BF3026 /* sell_updatePaymentIntent.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0319F2F92667995B00C01E1F /* sell_updatePaymentIntent.graphql.swift */; };
 		3E78BCF326B8231800BF3026 /* analytics_putAnalyticEvent.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0319F2F22667995A00C01E1F /* analytics_putAnalyticEvent.graphql.swift */; };
 		3E78BCF426B8231800BF3026 /* canvas_getWidgetsByScreenType.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0319F30D2667995B00C01E1F /* canvas_getWidgetsByScreenType.graphql.swift */; };
@@ -47,8 +46,6 @@
 		3E78BD1726B8231800BF3026 /* Types.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0319F2FB2667995B00C01E1F /* Types.graphql.swift */; };
 		3E78BD1826B8231800BF3026 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		3E78BD1926B8231800BF3026 /* sell_fragment_product.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0319F3122667995B00C01E1F /* sell_fragment_product.graphql.swift */; };
-		3E78BD1A26B8239300BF3026 /* GraphQL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E78BCEA26B8226800BF3026 /* GraphQL.framework */; };
-		3E78BD1B26B8239300BF3026 /* GraphQL.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E78BCEA26B8226800BF3026 /* GraphQL.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3E78BD2226B83F0300BF3026 /* schema.json in Resources */ = {isa = PBXBuildFile; fileRef = 961C41AB260882BA001D8467 /* schema.json */; };
 		480BCD94251E254D00266617 /* SDKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480BCD92251E254D00266617 /* SDKConfiguration.swift */; };
 		480BCD95251E254D00266617 /* RealifeTech.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480BCD93251E254D00266617 /* RealifeTech.swift */; };
@@ -301,13 +298,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		3E78BD1C26B8239300BF3026 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 48E67726251BA7F0007E2741 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3E78BCE926B8226800BF3026;
-			remoteInfo = GraphQL;
-		};
 		48D6F144251E158E006CA623 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 48E67726251BA7F0007E2741 /* Project object */;
@@ -315,21 +305,14 @@
 			remoteGlobalIDString = 48D6F139251E158E006CA623;
 			remoteInfo = RealifeTech;
 		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		3E78BD1E26B8239300BF3026 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				3E78BD1B26B8239300BF3026 /* GraphQL.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
+		96FC143826CC1683004E4816 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 48E67726251BA7F0007E2741 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3E78BCE926B8226800BF3026;
+			remoteInfo = GraphQL;
 		};
-/* End PBXCopyFilesBuildPhase section */
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		0319F2EB2667995A00C01E1F /* sell_createPaymentIntent.graphql.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = sell_createPaymentIntent.graphql.swift; sourceTree = "<group>"; };
@@ -375,7 +358,6 @@
 		3702AE9C18F340B82ED9978C /* Pods-RealifeTech.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealifeTech.debug.xcconfig"; path = "Target Support Files/Pods-RealifeTech/Pods-RealifeTech.debug.xcconfig"; sourceTree = "<group>"; };
 		3A2CC4D70E6F02FA1EE712F2 /* Pods-RealifeTech-RealifeTechTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealifeTech-RealifeTechTests.debug.xcconfig"; path = "Target Support Files/Pods-RealifeTech-RealifeTechTests/Pods-RealifeTech-RealifeTechTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3E78BCEA26B8226800BF3026 /* GraphQL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GraphQL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3E78BCEC26B8226800BF3026 /* GraphQL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GraphQL.h; sourceTree = "<group>"; };
 		3E78BCED26B8226800BF3026 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		480BCD8D251E252600266617 /* GeneralImplementing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneralImplementing.swift; sourceTree = "<group>"; };
 		480BCD92251E254D00266617 /* SDKConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKConfiguration.swift; sourceTree = "<group>"; };
@@ -645,7 +627,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3E78BD1A26B8239300BF3026 /* GraphQL.framework in Frameworks */,
 				D1A307806D5B3AE84B11702B /* Pods_RealifeTech.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -685,7 +666,6 @@
 			children = (
 				961C41AB260882BA001D8467 /* schema.json */,
 				961C419B260882BA001D8467 /* API */,
-				3E78BCEC26B8226800BF3026 /* GraphQL.h */,
 				3E78BCED26B8226800BF3026 /* Info.plist */,
 			);
 			path = GraphQL;
@@ -1685,7 +1665,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3E78BCEE26B8226800BF3026 /* GraphQL.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1730,12 +1709,11 @@
 				48D6F138251E158E006CA623 /* Resources */,
 				48D6F137251E158E006CA623 /* Frameworks */,
 				48D6F15B251E18A0006CA623 /* ShellScript */,
-				3E78BD1E26B8239300BF3026 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				3E78BD1D26B8239300BF3026 /* PBXTargetDependency */,
+				96FC143926CC1683004E4816 /* PBXTargetDependency */,
 			);
 			name = RealifeTech;
 			productName = RealifeTech;
@@ -2275,15 +2253,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		3E78BD1D26B8239300BF3026 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 3E78BCE926B8226800BF3026 /* GraphQL */;
-			targetProxy = 3E78BD1C26B8239300BF3026 /* PBXContainerItemProxy */;
-		};
 		48D6F145251E158E006CA623 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 48D6F139251E158E006CA623 /* RealifeTech */;
 			targetProxy = 48D6F144251E158E006CA623 /* PBXContainerItemProxy */;
+		};
+		96FC143926CC1683004E4816 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3E78BCE926B8226800BF3026 /* GraphQL */;
+			targetProxy = 96FC143826CC1683004E4816 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2374,6 +2352,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = RealifeTech/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -2383,11 +2362,12 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3.0;
-				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.concertlive.RealifeTech;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
+				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2405,6 +2385,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = RealifeTech/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -2414,11 +2395,12 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3.0;
-				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.concertlive.RealifeTech;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
+				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Sell/Basket/Models/Basket.swift
+++ b/Sell/Basket/Models/Basket.swift
@@ -7,6 +7,12 @@
 //
 
 import Foundation
+// Note. Why do we need this macro?
+// The host app fails to compile the project due to error No such module 'GraphQL' in SDK files.
+// This is caused by multiple targets in the ios-sdk when creating a framework via CocoaPods.
+// We import GraphQL to the places that need it,
+// but because CocoaPods generates a single product (framework) for all subspecs (sub-targets),
+// this would not be required for CocoaPods, and would result in a compile error.
 #if !COCOAPODS
 import GraphQL
 #endif

--- a/Sell/Basket/Models/Basket.swift
+++ b/Sell/Basket/Models/Basket.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct Basket: Codable, Equatable {
 

--- a/Sell/Basket/Models/BasketItem.swift
+++ b/Sell/Basket/Models/BasketItem.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct BasketItem: Codable, Equatable {
 

--- a/Sell/Basket/Models/CollectionPreferenceType.swift
+++ b/Sell/Basket/Models/CollectionPreferenceType.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public enum CollectionPreferenceType: String, Codable {
 

--- a/Sell/Basket/Models/ProductModifierItemSelection.swift
+++ b/Sell/Basket/Models/ProductModifierItemSelection.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct ProductModifierItemSelection: Codable, Equatable {
 

--- a/Sell/Basket/Models/SeatInfo.swift
+++ b/Sell/Basket/Models/SeatInfo.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct SeatInfo: Codable, Equatable {
 

--- a/Sell/Basket/Repository/BasketRepository.swift
+++ b/Sell/Basket/Repository/BasketRepository.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 import Apollo
 
 public final class BasketRepository {

--- a/Sell/FulfilmentPoint/Models/FulfilmentPoint.swift
+++ b/Sell/FulfilmentPoint/Models/FulfilmentPoint.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct FulfilmentPoint: Codable, Equatable {
 

--- a/Sell/FulfilmentPoint/Models/FulfilmentPointCategory.swift
+++ b/Sell/FulfilmentPoint/Models/FulfilmentPointCategory.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct FulfilmentPointCategory: Codable, Equatable {
 

--- a/Sell/FulfilmentPoint/Models/FulfilmentPointFilter.swift
+++ b/Sell/FulfilmentPoint/Models/FulfilmentPointFilter.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct FulfilmentPointFilter {
 

--- a/Sell/FulfilmentPoint/Models/FulfilmentPointTranslation.swift
+++ b/Sell/FulfilmentPoint/Models/FulfilmentPointTranslation.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct FulfilmentPointTranslation: Codable, Equatable {
 

--- a/Sell/FulfilmentPoint/Models/Timeslot.swift
+++ b/Sell/FulfilmentPoint/Models/Timeslot.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct Timeslot: Codable, Equatable {
 

--- a/Sell/FulfilmentPoint/Repository/FulfilmentPointRepository.swift
+++ b/Sell/FulfilmentPoint/Repository/FulfilmentPointRepository.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public final class FulfilmentPointRepository {
 

--- a/Sell/Order/Models/Order.swift
+++ b/Sell/Order/Models/Order.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct Order: Codable, Equatable {
 

--- a/Sell/Order/Models/OrderItem.swift
+++ b/Sell/Order/Models/OrderItem.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct OrderItem: Codable, Equatable {
 

--- a/Sell/Order/Models/OrderState.swift
+++ b/Sell/Order/Models/OrderState.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct OrderState: Codable, Equatable {
 

--- a/Sell/Order/Models/OrderStatus.swift
+++ b/Sell/Order/Models/OrderStatus.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public enum OrderStatus: String, Codable {
 

--- a/Sell/Order/Repository/OrderRepository.swift
+++ b/Sell/Order/Repository/OrderRepository.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public final class OrderRepository {
 

--- a/Sell/Payment/Models/PaymentIntent/CancellationReason.swift
+++ b/Sell/Payment/Models/PaymentIntent/CancellationReason.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public enum CancellationReason: String, Codable {
 

--- a/Sell/Payment/Models/PaymentIntent/OrderType.swift
+++ b/Sell/Payment/Models/PaymentIntent/OrderType.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public enum OrderType: String, Codable {
 

--- a/Sell/Payment/Models/PaymentIntent/PaymentActionType.swift
+++ b/Sell/Payment/Models/PaymentIntent/PaymentActionType.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public enum PaymentActionType: String, Codable {
 

--- a/Sell/Payment/Models/PaymentIntent/PaymentIntent.swift
+++ b/Sell/Payment/Models/PaymentIntent/PaymentIntent.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct PaymentIntent: Codable, Equatable {
 

--- a/Sell/Payment/Models/PaymentIntent/PaymentIntentInput.swift
+++ b/Sell/Payment/Models/PaymentIntent/PaymentIntentInput.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct PaymentIntentInput {
 

--- a/Sell/Payment/Models/PaymentIntent/PaymentIntentUpdateInput.swift
+++ b/Sell/Payment/Models/PaymentIntent/PaymentIntentUpdateInput.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct PaymentIntentUpdateInput {
 

--- a/Sell/Payment/Models/PaymentIntent/PaymentStatus.swift
+++ b/Sell/Payment/Models/PaymentIntent/PaymentStatus.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public enum PaymentStatus: String, Codable {
 

--- a/Sell/Payment/Models/PaymentSource/Card.swift
+++ b/Sell/Payment/Models/PaymentSource/Card.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct Card: Codable, Equatable {
 

--- a/Sell/Payment/Models/PaymentSource/CardInput.swift
+++ b/Sell/Payment/Models/PaymentSource/CardInput.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct CardInput: Equatable {
 

--- a/Sell/Payment/Models/PaymentSource/PaymentSource.swift
+++ b/Sell/Payment/Models/PaymentSource/PaymentSource.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct PaymentSource: Codable, Equatable {
 

--- a/Sell/Payment/Models/PaymentSource/PaymentSourceBillingDetails.swift
+++ b/Sell/Payment/Models/PaymentSource/PaymentSourceBillingDetails.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct PaymentSourceBillingDetails: Codable, Equatable {
 

--- a/Sell/Payment/Models/PaymentSource/PaymentSourceInput.swift
+++ b/Sell/Payment/Models/PaymentSource/PaymentSourceInput.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct PaymentSourceInput {
 

--- a/Sell/Payment/Repository/PaymentRepository.swift
+++ b/Sell/Payment/Repository/PaymentRepository.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public final class PaymentRepository {
 

--- a/Sell/Product/Models/Product.swift
+++ b/Sell/Product/Models/Product.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct Product: Codable, Equatable {
 

--- a/Sell/Product/Models/ProductCategory.swift
+++ b/Sell/Product/Models/ProductCategory.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct ProductCategory: Codable, Equatable {
 

--- a/Sell/Product/Models/ProductImage.swift
+++ b/Sell/Product/Models/ProductImage.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct ProductImage: Codable, Equatable {
 

--- a/Sell/Product/Models/ProductModifierItem.swift
+++ b/Sell/Product/Models/ProductModifierItem.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct ProductModifierItem: Codable, Equatable {
 

--- a/Sell/Product/Models/ProductModifierList.swift
+++ b/Sell/Product/Models/ProductModifierList.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct ProductModifierList: Codable, Equatable {
 

--- a/Sell/Product/Models/ProductVariant.swift
+++ b/Sell/Product/Models/ProductVariant.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct ProductVariant: Codable, Equatable {
 

--- a/Sell/Product/Repository/ProductRepository.swift
+++ b/Sell/Product/Repository/ProductRepository.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public final class ProductRepository {
 

--- a/Sell/Utils/FilterParam.swift
+++ b/Sell/Utils/FilterParam.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if !COCOAPODS
 import GraphQL
+#endif
 
 public struct FilterParam: Codable, Equatable {
 


### PR DESCRIPTION
The host app fails to compile the project due to error `No such module 'GraphQL'` in SDK files. This is caused by multiple targets in the project when creating a framework via CocoaPods.

Basically, we import GraphQL to the places that need it, but because CocoaPods generates a single product (framework) for all subspecs (sub-targets), this would not be required for CocoaPods, and would result in a compile error.

Referencing from Apollo SDK, I add this syntax `#if !COCOAPODS` before importing `GraphQL` target to allow the project import when CocoaPods is in use. However, the project file still needs some tweaks to compile successfully. The GraphQL framework doesn't need to be a link library in RealifeTech target. Instead, the GraphQL is only a dependency of the RealifeTech target. By removing GraphQL from the linked library, both DummyProject and frontier.ios are able to compile.

<img width="665" alt="Screenshot 2021-08-17 at 18 09 20" src="https://user-images.githubusercontent.com/51782336/129771899-42769c75-662f-4ee1-b6c4-081ada270efc.png">
<img width="836" alt="Screenshot 2021-08-17 at 18 09 37" src="https://user-images.githubusercontent.com/51782336/129771908-7bf9a8ac-8f67-4874-a152-83f3bd98168a.png">

@You-Hsuan Could you test this branch with fontier.ios please?
