### PR TITLE
WOD-1: Improve coverage

### DIFF
--- a/Core/CombineHelpers/AnyScheduler.swift
+++ b/Core/CombineHelpers/AnyScheduler.swift
@@ -1,0 +1,104 @@
+//
+//  AnyScheduler.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 23/08/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+final class AnyScheduler<S: Scheduler>: AnySchedulerBase<S.SchedulerTimeType, S.SchedulerOptions> { }
+
+typealias DispatchQueueAnyScheduler = AnyScheduler<DispatchQueue>
+
+class AnySchedulerBase<Time: Strideable, Options>: Scheduler where Time.Stride: SchedulerTimeIntervalConvertible {
+
+    typealias SchedulerTimeType = Time
+    typealias SchedulerOptions = Options
+
+    var now: Time { _now() }
+    var minimumTolerance: Time.Stride { _minimumTolerance() }
+
+    private let _now: () -> Time
+    private let _minimumTolerance: () -> Time.Stride
+    private let _schedule: (
+        _ options: Options?,
+        _ action: @escaping () -> Void) -> Void
+    private let _scheduleAfter: (
+        _ date: Time,
+        _ tolerance: Time.Stride,
+        _ options: SchedulerOptions?,
+        _ action: @escaping () -> Void) -> Void
+    private let _scheduleAfterCancellable: (
+        _ date: SchedulerTimeType,
+        _ interval: SchedulerTimeType.Stride,
+        _ tolerance: SchedulerTimeType.Stride,
+        _ options: SchedulerOptions?,
+        _ action: @escaping () -> Void) -> Cancellable
+
+    init<S: Scheduler>(scheduler: S) where S.SchedulerTimeType == Time, S.SchedulerOptions == Options {
+        _now = { scheduler.now }
+        _minimumTolerance = { scheduler.minimumTolerance }
+        _schedule = { options, action in
+            scheduler.schedule(options: options, action)
+        }
+        _scheduleAfter = { date, tolerance, options, action in
+            scheduler.schedule(
+                after: date,
+                tolerance: tolerance,
+                options: options,
+                action)
+        }
+        _scheduleAfterCancellable = { date, interval, tolerance, options, action in
+            scheduler.schedule(
+                after: date,
+                interval: interval,
+                tolerance: tolerance,
+                options: options,
+                action)
+        }
+    }
+
+    func schedule(options: Options?, _ action: @escaping () -> Void) {
+        _schedule(options, action)
+    }
+
+    func schedule(
+        after date: Time,
+        tolerance: Time.Stride,
+        options: Options?,
+        _ action: @escaping () -> Void
+    ) {
+        _scheduleAfter(date, tolerance, options, action)
+    }
+
+    func schedule(
+        after date: Time,
+        interval: Time.Stride,
+        tolerance: Time.Stride,
+        options: Options?, _ action: @escaping () -> Void
+    ) -> Cancellable {
+        _scheduleAfterCancellable(date, interval, tolerance, options, action)
+    }
+}
+
+extension Scheduler {
+
+    func eraseToAnyScheduler<S: Scheduler>() -> AnyScheduler<S>
+    where S.SchedulerOptions == SchedulerOptions, S.SchedulerTimeType == SchedulerTimeType {
+        AnyScheduler(scheduler: self)
+    }
+}
+
+extension AnyScheduler where S: DispatchQueue {
+
+    static var main: AnyScheduler<DispatchQueue> {
+        DispatchQueue.main.eraseToAnyScheduler()
+    }
+
+    static func global(qos: DispatchQoS.QoSClass = .default) -> AnyScheduler<DispatchQueue> {
+        DispatchQueue.global(qos: qos).eraseToAnyScheduler()
+    }
+}

--- a/Core/CombineHelpers/Tests/AnySchedulerTests.swift
+++ b/Core/CombineHelpers/Tests/AnySchedulerTests.swift
@@ -1,0 +1,52 @@
+//
+//  AnySchedulerTests.swift
+//  RealifeTechTests
+//
+//  Created by Mickey Lee on 23/08/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import XCTest
+import Combine
+@testable import RealifeTech
+
+final class AnySchedulerTests: XCTestCase {
+
+    private var bag: Set<AnyCancellable> = []
+
+    func test_scheduleOptions() {
+        let sut = DispatchQueueAnyScheduler.global()
+        let expectation = XCTestExpectation(description: "callback is fulfilled")
+        sut.schedule(options: nil) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.01)
+    }
+
+    func test_scheduleAfter() {
+        let sut = DispatchQueueAnyScheduler.global()
+        let expectation = XCTestExpectation(description: "callback is fulfilled")
+        sut.schedule(
+            after: sut.now.advanced(by: 0.001),
+            tolerance: .zero,
+            options: nil
+        ) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.01)
+    }
+
+    func test_scheduleAfterCancellable() {
+        let sut = DispatchQueueAnyScheduler.global()
+        let expectation = XCTestExpectation(description: "callback is fulfilled")
+        sut.schedule(
+            after: sut.now.advanced(by: 0.001),
+            interval: 0.001,
+            tolerance: .zero,
+            options: nil
+        ) {
+            expectation.fulfill()
+        }.store(in: &bag)
+        wait(for: [expectation], timeout: 0.01)
+    }
+}

--- a/Core/CombineHelpers/Tests/DispatchQueueTestScheduler.swift
+++ b/Core/CombineHelpers/Tests/DispatchQueueTestScheduler.swift
@@ -1,0 +1,112 @@
+//
+//  DispatchQueueTestScheduler.swift
+//  RealifeTechTests
+//
+//  Created by Mickey Lee on 23/08/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+import Combine
+@testable import RealifeTech
+
+final class DispatchQueueTestScheduler: Scheduler {
+
+    typealias SchedulerTimeType = DispatchQueue.SchedulerTimeType
+    typealias SchedulerOptions = DispatchQueue.SchedulerOptions
+
+    // Scheduler needs to be advanced before execution for delayed actions with interval
+    var enableImmediateExecutionIfPossible = true
+    var now: DispatchQueue.SchedulerTimeType
+    var minimumTolerance: DispatchQueue.SchedulerTimeType.Stride
+    var immediateActions: [ImmediateAction] = []
+    var delayedActions: [DelayedAction] = []
+    var delayedIntervalActions: [DelayedIntervalAction] = []
+
+    init() {
+        now = .init(.now())
+        minimumTolerance = .zero
+    }
+
+    func advance(by interval: DispatchQueue.SchedulerTimeType.Stride) {
+        now = now.advanced(by: interval)
+    }
+
+    func schedule(options: DispatchQueue.SchedulerOptions?, _ action: @escaping () -> Void) {
+        immediateActions.append(ImmediateAction(options: options, action: action))
+        if enableImmediateExecutionIfPossible {
+            action()
+        }
+    }
+
+    func schedule(
+        after: SchedulerTimeType,
+        tolerance: SchedulerTimeType.Stride,
+        options: SchedulerOptions?,
+        _ action: @escaping () -> Void
+    ) {
+        let delayedAction = DelayedAction(
+            after: after,
+            tolerance: tolerance,
+            options: options,
+            action: action
+        )
+        delayedActions.append(delayedAction)
+        if enableImmediateExecutionIfPossible {
+            action()
+        }
+    }
+
+    func schedule(
+        after: SchedulerTimeType,
+        interval: SchedulerTimeType.Stride,
+        tolerance: SchedulerTimeType.Stride,
+        options: SchedulerOptions?,
+        _ action: @escaping () -> Void
+    ) -> Cancellable {
+        let delayedIntervalAction = DelayedIntervalAction(
+            after: after,
+            interval: interval,
+            tolerance: tolerance,
+            options: options,
+            action: action
+        )
+        delayedIntervalActions.append(delayedIntervalAction)
+        return AnyCancellable { [weak self] in
+            self?.delayedIntervalActions.removeAll(where: { $0.uuid == delayedIntervalAction.uuid })
+        }
+    }
+}
+
+extension DispatchQueueTestScheduler {
+
+    struct ImmediateAction {
+        let uuid = UUID()
+        let options: DispatchQueue.SchedulerOptions?
+        let action: () -> Void
+    }
+
+    struct DelayedAction {
+        let uuid = UUID()
+        let after: SchedulerTimeType
+        let tolerance: SchedulerTimeType.Stride
+        let options: SchedulerOptions?
+        let action: () -> Void
+    }
+
+    struct DelayedIntervalAction {
+        let uuid = UUID()
+        let after: SchedulerTimeType
+        let interval: SchedulerTimeType.Stride
+        let tolerance: SchedulerTimeType.Stride
+        let options: SchedulerOptions?
+        let action: () -> Void
+    }
+}
+
+extension AnyScheduler where S: DispatchQueue {
+
+    static var test: AnyScheduler<DispatchQueue> {
+        DispatchQueueTestScheduler().eraseToAnyScheduler()
+    }
+}

--- a/Core/SwiftUIHelpers/Inspection.swift
+++ b/Core/SwiftUIHelpers/Inspection.swift
@@ -1,0 +1,21 @@
+//
+//  Inspection.swift
+//  RealifeTech
+//
+//  Created by Mickey Lee on 23/08/2021.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Combine
+import SwiftUI
+
+final class Inspection<V> {
+
+    let notice = PassthroughSubject<UInt, Never>()
+    var callbacks: [UInt: (V) -> Void] = [:]
+
+    func visit(_ view: V, _ line: UInt) {
+        guard let callback = callbacks.removeValue(forKey: line) else { return }
+        callback(view)
+    }
+}

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		96B6706F26D3E5C100DB74A4 /* AnyScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B6706E26D3E5C100DB74A4 /* AnyScheduler.swift */; };
 		96B6707126D3ECAA00DB74A4 /* DispatchQueueTestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B6707026D3ECAA00DB74A4 /* DispatchQueueTestScheduler.swift */; };
 		96B6707326D3F0F300DB74A4 /* AnySchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B6707226D3F0F300DB74A4 /* AnySchedulerTests.swift */; };
+		96B6707526D3FD2800DB74A4 /* Inspection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B6707426D3FD2800DB74A4 /* Inspection.swift */; };
 		96CE697826CE54DD0026CC13 /* OrderingJourneyViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CE697726CE54DD0026CC13 /* OrderingJourneyViewTests.swift */; };
 		96CE698226CEA02E0026CC13 /* SellImplementingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CE698126CEA02E0026CC13 /* SellImplementingTests.swift */; };
 		96F1BF1E26CD2F3C008D1363 /* OrderingJourneyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F1BF1D26CD2F3C008D1363 /* OrderingJourneyViewController.swift */; };
@@ -640,6 +641,7 @@
 		96B6706E26D3E5C100DB74A4 /* AnyScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyScheduler.swift; sourceTree = "<group>"; };
 		96B6707026D3ECAA00DB74A4 /* DispatchQueueTestScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueTestScheduler.swift; sourceTree = "<group>"; };
 		96B6707226D3F0F300DB74A4 /* AnySchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnySchedulerTests.swift; sourceTree = "<group>"; };
+		96B6707426D3FD2800DB74A4 /* Inspection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inspection.swift; sourceTree = "<group>"; };
 		96CE697726CE54DD0026CC13 /* OrderingJourneyViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderingJourneyViewTests.swift; sourceTree = "<group>"; };
 		96CE698126CEA02E0026CC13 /* SellImplementingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellImplementingTests.swift; sourceTree = "<group>"; };
 		96F1BF1D26CD2F3C008D1363 /* OrderingJourneyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderingJourneyViewController.swift; sourceTree = "<group>"; };
@@ -1714,6 +1716,7 @@
 			isa = PBXGroup;
 			children = (
 				96AED8CD26CFB58A00F6C750 /* Color+Hex.swift */,
+				96B6707426D3FD2800DB74A4 /* Inspection.swift */,
 				96AED8CF26CFB5B600F6C750 /* NavigationBarModifier.swift */,
 			);
 			path = SwiftUIHelpers;
@@ -2239,6 +2242,7 @@
 				9606ED97267B646F00ED24D0 /* SellImplementing.swift in Sources */,
 				9606ED89267B50B000ED24D0 /* ProductFilter.swift in Sources */,
 				961C425C260882C8001D8467 /* AnalyticEvent.swift in Sources */,
+				96B6707526D3FD2800DB74A4 /* Inspection.swift in Sources */,
 				487479CE254044430048F03D /* AnalyticsFactory.swift in Sources */,
 				961C41CE260882BA001D8467 /* APITokenManager.swift in Sources */,
 				961C1C8C268206EC00BE6F3B /* FulfilmentPointTranslation.swift in Sources */,

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -302,6 +302,9 @@
 		96AED8D026CFB5B600F6C750 /* NavigationBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AED8CF26CFB5B600F6C750 /* NavigationBarModifier.swift */; };
 		96AED8D326CFBC9A00F6C750 /* EmptyColorStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AED8D226CFBC9A00F6C750 /* EmptyColorStoreTests.swift */; };
 		96AED8D526CFC71900F6C750 /* ColorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AED8D426CFC71900F6C750 /* ColorTypeTests.swift */; };
+		96B6706F26D3E5C100DB74A4 /* AnyScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B6706E26D3E5C100DB74A4 /* AnyScheduler.swift */; };
+		96B6707126D3ECAA00DB74A4 /* DispatchQueueTestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B6707026D3ECAA00DB74A4 /* DispatchQueueTestScheduler.swift */; };
+		96B6707326D3F0F300DB74A4 /* AnySchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B6707226D3F0F300DB74A4 /* AnySchedulerTests.swift */; };
 		96CE697826CE54DD0026CC13 /* OrderingJourneyViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CE697726CE54DD0026CC13 /* OrderingJourneyViewTests.swift */; };
 		96CE698226CEA02E0026CC13 /* SellImplementingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CE698126CEA02E0026CC13 /* SellImplementingTests.swift */; };
 		96F1BF1E26CD2F3C008D1363 /* OrderingJourneyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F1BF1D26CD2F3C008D1363 /* OrderingJourneyViewController.swift */; };
@@ -634,6 +637,9 @@
 		96AED8CF26CFB5B600F6C750 /* NavigationBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifier.swift; sourceTree = "<group>"; };
 		96AED8D226CFBC9A00F6C750 /* EmptyColorStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyColorStoreTests.swift; sourceTree = "<group>"; };
 		96AED8D426CFC71900F6C750 /* ColorTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTypeTests.swift; sourceTree = "<group>"; };
+		96B6706E26D3E5C100DB74A4 /* AnyScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyScheduler.swift; sourceTree = "<group>"; };
+		96B6707026D3ECAA00DB74A4 /* DispatchQueueTestScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueTestScheduler.swift; sourceTree = "<group>"; };
+		96B6707226D3F0F300DB74A4 /* AnySchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnySchedulerTests.swift; sourceTree = "<group>"; };
 		96CE697726CE54DD0026CC13 /* OrderingJourneyViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderingJourneyViewTests.swift; sourceTree = "<group>"; };
 		96CE698126CEA02E0026CC13 /* SellImplementingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellImplementingTests.swift; sourceTree = "<group>"; };
 		96F1BF1D26CD2F3C008D1363 /* OrderingJourneyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderingJourneyViewController.swift; sourceTree = "<group>"; };
@@ -1274,6 +1280,7 @@
 		961C41AC260882BA001D8467 /* CombineHelpers */ = {
 			isa = PBXGroup;
 			children = (
+				96B6706E26D3E5C100DB74A4 /* AnyScheduler.swift */,
 				961C41AF260882BA001D8467 /* ReadOnlyCurrentValue.swift */,
 				961C41AD260882BA001D8467 /* Tests */,
 			);
@@ -1283,6 +1290,8 @@
 		961C41AD260882BA001D8467 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				96B6707226D3F0F300DB74A4 /* AnySchedulerTests.swift */,
+				96B6707026D3ECAA00DB74A4 /* DispatchQueueTestScheduler.swift */,
 				961C41AE260882BA001D8467 /* ReadOnlyCurrentValueTests.swift */,
 			);
 			path = Tests;
@@ -2224,6 +2233,7 @@
 				961B01A32689F3D300D8C481 /* OrderUpdateInput.swift in Sources */,
 				480BCD94251E254D00266617 /* SDKConfiguration.swift in Sources */,
 				961C1CCB2684E3B200BE6F3B /* ProductModifierItemSelection.swift in Sources */,
+				96B6706F26D3E5C100DB74A4 /* AnyScheduler.swift in Sources */,
 				968CA62325EF69370000C2E2 /* ContentFactory.swift in Sources */,
 				961C1CA72683405400BE6F3B /* ProductVariant.swift in Sources */,
 				9606ED97267B646F00ED24D0 /* SellImplementing.swift in Sources */,
@@ -2300,6 +2310,7 @@
 				96AED8D326CFBC9A00F6C750 /* EmptyColorStoreTests.swift in Sources */,
 				961C1CD42685D6DC00BE6F3B /* BasketRepositoryQueryTests.swift in Sources */,
 				961C42AC2608832D001D8467 /* BluetoothManagerWrapperTests.swift in Sources */,
+				96B6707326D3F0F300DB74A4 /* AnySchedulerTests.swift in Sources */,
 				961C4285260882E4001D8467 /* RequestCreatorTests.swift in Sources */,
 				961C436626089360001D8467 /* APITokenManagerTests.swift in Sources */,
 				961C436D2608936E001D8467 /* OAuthTokenRefreshWatcherTests.swift in Sources */,
@@ -2337,6 +2348,7 @@
 				9687488C268DB9A400DDC5DD /* PaymentRepositoryTestHelper.swift in Sources */,
 				96302CE626C3E9EA000A91EC /* APITokenInterceptorTests.swift in Sources */,
 				9606EDBE267CA6A400ED24D0 /* MockGraphQLManager.swift in Sources */,
+				96B6707126D3ECAA00DB74A4 /* DispatchQueueTestScheduler.swift in Sources */,
 				961C42C42608836E001D8467 /* RemoteDiskCacheDataProvidingTests.swift in Sources */,
 				96F1BF3C26CD6AC6008D1363 /* OrderingJourneyViewControllerTests.swift in Sources */,
 				961C436326089346001D8467 /* AuthorisationWorkerTests.swift in Sources */,

--- a/Sell/OrderingJourney/Tests/OrderingJourneyViewTests.swift
+++ b/Sell/OrderingJourney/Tests/OrderingJourneyViewTests.swift
@@ -8,21 +8,29 @@
 
 import XCTest
 import SwiftUI
+import Combine
 import ViewInspector
 @testable import RealifeTech
 
 final class OrderingJourneyViewTests: XCTestCase {
 
     private var sut: OrderingJourneyView!
+    private var scheduler: DispatchQueueTestScheduler!
+    private var bag = Set<AnyCancellable>()
     private let urlString = "https://www.google.com"
 
     override func setUp() {
         super.setUp()
-        sut = OrderingJourneyView(urlString: urlString, colorStore: EmptyColorStore())
+        scheduler = DispatchQueueTestScheduler()
+        sut = OrderingJourneyView(
+            urlString: urlString,
+            colorStore: EmptyColorStore(),
+            scheduler: scheduler.eraseToAnyScheduler())
     }
 
     override func tearDown() {
         sut = nil
+        scheduler = nil
         super.tearDown()
     }
 
@@ -40,4 +48,62 @@ final class OrderingJourneyViewTests: XCTestCase {
         let forwardButton = try bottomView.vStack().hStack(0).button(1)
         XCTAssertTrue(forwardButton.isDisabled())
     }
+
+    func test_goBackButtonTapped_webViewNavigationPublisherReceivesValue() throws {
+        let expectation1 = sut.inspection.inspect { [self] view in
+            let backwardButton = try getBottomViewFromInsepctedView(view).vStack().hStack(0).button(0)
+            XCTAssertTrue(backwardButton.isDisabled())
+            XCTAssertEqual(try backwardButton.foregroundColor(), sut.colorStore.getColor(for: .neutral))
+            sut.store.canGoBack.send(true)
+        }
+        let expectation2 = sut.inspection.inspect(onReceive: sut.store.canGoBack) { [self] view in
+            let backwardButton = try getBottomViewFromInsepctedView(view).vStack().hStack(0).button(0)
+            XCTAssertFalse(backwardButton.isDisabled())
+            XCTAssertEqual(try backwardButton.foregroundColor(), sut.colorStore.getColor(for: .onSurface))
+            try backwardButton.tap()
+        }
+        let expectation3 = XCTestExpectation(description: "final")
+        sut.store.webViewNavigationPublisher
+            .sink { receivedNavigation in
+                XCTAssertEqual(receivedNavigation, .backward)
+                expectation3.fulfill()
+            }.store(in: &bag)
+        ViewHosting.host(view: sut)
+        wait(for: [expectation1, expectation2, expectation3], timeout: 1)
+    }
+
+    func test_goForwardButtonTapped_webViewNavigationPublisherReceivesValue() throws {
+        let expectation1 = sut.inspection.inspect { [self] view in
+            let forwardButton = try getBottomViewFromInsepctedView(view).vStack().hStack(0).button(1)
+            XCTAssertTrue(forwardButton.isDisabled())
+            XCTAssertEqual(try forwardButton.foregroundColor(), sut.colorStore.getColor(for: .neutral))
+            sut.store.canGoForward.send(true)
+        }
+        let expectation2 = sut.inspection.inspect(onReceive: sut.store.canGoForward) { [self] view in
+            let forwardButton = try getBottomViewFromInsepctedView(view).vStack().hStack(0).button(1)
+            XCTAssertFalse(forwardButton.isDisabled())
+            XCTAssertEqual(try forwardButton.foregroundColor(), sut.colorStore.getColor(for: .onSurface))
+            try forwardButton.tap()
+        }
+        let expectation3 = XCTestExpectation(description: "final")
+        sut.store.webViewNavigationPublisher
+            .sink { receivedNavigation in
+                XCTAssertEqual(receivedNavigation, .forward)
+                expectation3.fulfill()
+            }.store(in: &bag)
+        ViewHosting.host(view: sut)
+        wait(for: [expectation1, expectation2, expectation3], timeout: 1)
+    }
+
+    private func getBottomViewFromInsepctedView(
+        _ view: InspectableView<ViewType.View<OrderingJourneyView>>
+    ) throws -> InspectableView<ViewType.AnyView> {
+        let navigationView = try view.navigationView()
+            .navigationBarItems(VStack<TupleView<(WebViewWrapper, AnyView)>>.self)
+        let vStack = try navigationView.vStack(0)
+        return try vStack.anyView(1)
+    }
 }
+
+extension Inspection: InspectionEmissary { }
+extension OrderingJourneyView: Inspectable { }

--- a/Sell/OrderingJourney/Tests/WebViewWrapperTests.swift
+++ b/Sell/OrderingJourney/Tests/WebViewWrapperTests.swift
@@ -18,6 +18,7 @@ final class WebViewWrapperTests: XCTestCase {
     private var url: URL!
     private var urlRequest: URLRequest!
     private var store: WebViewStore!
+    private var scheduler: DispatchQueueTestScheduler!
     private var sut: WebViewWrapper!
     private var bag = Set<AnyCancellable>()
 
@@ -27,14 +28,17 @@ final class WebViewWrapperTests: XCTestCase {
         url = try XCTUnwrap(URL(string: "https://www.google.com"))
         urlRequest = URLRequest(url: url)
         store = WebViewStore()
+        scheduler = DispatchQueueTestScheduler()
         sut = WebViewWrapper(
             webView: webView,
             urlRequest: urlRequest,
-            store: store)
+            store: store,
+            scheduler: scheduler.eraseToAnyScheduler())
     }
 
     override func tearDown() {
         sut = nil
+        scheduler = nil
         store = nil
         urlRequest = nil
         url = nil
@@ -63,15 +67,35 @@ final class WebViewWrapperTests: XCTestCase {
         XCTAssertEqual(receivedPolicy, .allow)
     }
 
-//    func test_coordinatorDidStartProvisionalNavigation() {
-//        let wkNavigation = createNavigation(url: url, webView: webView)
-//        let coordinator = sut.makeCoordinator()
-//        coordinator.webView(
-//            webView,
-//            didStartProvisionalNavigation: wkNavigation)
-//        store.webViewNavigationPublisher.send(.reload)
-//        XCTAssertTrue(webView.didReload)
-//    }
+    func test_coordinatorDidStartProvisionalNavigation_reloadNavigation_webViewDidReload() {
+        let wkNavigation = createNavigation(url: url, webView: webView)
+        let coordinator = sut.makeCoordinator()
+        coordinator.webView(
+            webView,
+            didStartProvisionalNavigation: wkNavigation)
+        store.webViewNavigationPublisher.send(.reload)
+        XCTAssertTrue(webView.didReload)
+    }
+
+    func test_coordinatorDidStartProvisionalNavigation_backwardNavigation_webViewGoesBack() {
+        let wkNavigation = createNavigation(url: url, webView: webView)
+        let coordinator = sut.makeCoordinator()
+        coordinator.webView(
+            webView,
+            didStartProvisionalNavigation: wkNavigation)
+        store.webViewNavigationPublisher.send(.backward)
+        XCTAssertTrue(webView.didGoBack)
+    }
+
+    func test_coordinatorDidStartProvisionalNavigation_forwardNavigation_webViewGoesForward() {
+        let wkNavigation = createNavigation(url: url, webView: webView)
+        let coordinator = sut.makeCoordinator()
+        coordinator.webView(
+            webView,
+            didStartProvisionalNavigation: wkNavigation)
+        store.webViewNavigationPublisher.send(.forward)
+        XCTAssertTrue(webView.didGoForward)
+    }
 
     func test_coodinatorWebViewDidFinishNavigation() {
         let wkNavigation = createNavigation(url: url, webView: webView)
@@ -89,15 +113,28 @@ final class WebViewWrapperTests: XCTestCase {
                 canGoForwardExpectation.fulfill()
             }
             .store(in: &bag)
-        wait(for: [canGoBackExpectation, canGoForwardExpectation], timeout: 0.05)
+        wait(for: [canGoBackExpectation, canGoForwardExpectation], timeout: 0.01)
     }
 }
 
 // MARK: - Mocks
 private final class MockWebView: WKWebView {
 
+    var shouldGoBack = true
+    var shouldGoForward = true
+
     var receivedUrl: URL?
     var didReload = false
+    var didGoBack = false
+    var didGoForward = false
+
+    override var canGoBack: Bool {
+        shouldGoBack
+    }
+
+    override var canGoForward: Bool {
+        shouldGoForward
+    }
 
     override func load(_ request: URLRequest) -> WKNavigation? {
         receivedUrl = request.url
@@ -106,6 +143,16 @@ private final class MockWebView: WKWebView {
 
     override func reload() -> WKNavigation? {
         didReload = true
+        return nil
+    }
+
+    override func goBack() -> WKNavigation? {
+        didGoBack = true
+        return nil
+    }
+
+    override func goForward() -> WKNavigation? {
+        didGoForward = true
         return nil
     }
 }

--- a/Sell/Tests/SellImplementingTests.swift
+++ b/Sell/Tests/SellImplementingTests.swift
@@ -12,21 +12,28 @@ import GraphQL
 
 final class SellImplementingTests: XCTestCase {
 
-    func test_createOrderingJourneyViewController() {
+    private var sut: SellImplementing!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         let graphQLManager = MockGraphQLManager<ApolloType.GetProductsQuery.Data>()
-        let sut = SellFactory.makeSellModule(
+        let sell = SellFactory.makeSellModule(
             graphQLManager: graphQLManager,
             orderingJourneyUrl: "",
             colorStore: EmptyColorStore())
+        sut = try XCTUnwrap(sell as? SellImplementing)
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    func test_createOrderingJourneyViewController() {
         XCTAssertTrue(sut.createOrderingJourneyViewController() is OrderingJourneyViewController)
     }
 
     func test_createOrderingJourneyView() {
-        let graphQLManager = MockGraphQLManager<ApolloType.GetProductsQuery.Data>()
-        let sut = SellFactory.makeSellModule(
-            graphQLManager: graphQLManager,
-            orderingJourneyUrl: "",
-            colorStore: EmptyColorStore())
         let view = sut.createOrderingJourneyView()
         XCTAssertNotNil(view.urlRequest.url)
     }


### PR DESCRIPTION
Improve code coverage on WebViewWrapper and OrderingJourneyView.
* WebViewWrapper: `sink(receiveValue:)` didn't get called in unit test due to scheduler. As a result, I've created `DispatchQueueAnyScheduler` to inject this. The usage is similar to RxSwift.Scheduler.
* OrderingJourneyView: Inspect the backward and forward buttons' state and action so that we can test `onReceive` closure.