### PR TITLE
Fix OrderType and WebPage

### DIFF
--- a/Content/WebPage/WebPage.swift
+++ b/Content/WebPage/WebPage.swift
@@ -12,6 +12,10 @@ public struct WebPage {
 
     public let url: URL
 
+    public init(url: URL) {
+        self.url = url
+    }
+
     public enum `Type`: String, CaseIterable {
         case audioGuidesHelp
         case tAndC

--- a/Sell/Payment/Models/PaymentIntent/OrderType.swift
+++ b/Sell/Payment/Models/PaymentIntent/OrderType.swift
@@ -13,7 +13,7 @@ import GraphQL
 
 public enum OrderType: String, Codable {
 
-    case foodAndBeverage = "food_and_beverage"
+    case foodAndBeverage
     case ticket
     case unknown
 

--- a/Sell/Payment/Models/PaymentIntent/OrderType.swift
+++ b/Sell/Payment/Models/PaymentIntent/OrderType.swift
@@ -13,7 +13,7 @@ import GraphQL
 
 public enum OrderType: String, Codable {
 
-    case foodAndBeverage
+    case foodAndBeverage = "food_and_beverage"
     case ticket
     case unknown
 


### PR DESCRIPTION
1. Add rawValue() to OrderType foodAndBeverage case, in order to init from the `basket.orderType.paymentIntentOrderType` in Frontier app
2. Need to add public init to WebPage so that the Frontier app can init WebPage. (The default access level for init function is internal )