### PR TITLE
MOD-289 Keep references of store and client on GraphQLManager

### DIFF
--- a/Core/GraphQL/GraphQLFactory.swift
+++ b/Core/GraphQL/GraphQLFactory.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Apollo
 
-public class GraphQLFactory {
+public struct GraphQLFactory {
 
     static let store: ApolloStore = {
         let documentsPath = NSSearchPathForDirectoriesInDomains(
@@ -22,40 +22,27 @@ public class GraphQLFactory {
         return ApolloStore(cache: sqliteCache ?? InMemoryNormalizedCache())
     }()
 
-    static let networkTransport: RequestChainNetworkTransport? = {
+    static func makeGraphQLManager(
+        deviceId: String,
+        tokenHelper: APITokenManagable,
+        graphQLAPIUrl: URL
+    ) -> GraphQLManageable {
         var headers: [String: String] = ["X-Ls-DeviceId": deviceId]
-        guard let tokenHelper = tokenHelper, let graphQLAPIUrl = graphQLAPIUrl else {
-            return nil
-        }
         if tokenHelper.tokenIsValid, let token = tokenHelper.token {
             headers["Authorization"] = "Bearer \(token)"
         }
-        let transport = RequestChainNetworkTransport(
+        let networkTransport = RequestChainNetworkTransport(
             interceptorProvider: GraphQLInterceptorProvider(
                 store: store,
                 client: URLSessionClient(),
                 tokenHelper: tokenHelper),
             endpointURL: graphQLAPIUrl,
             additionalHeaders: headers)
-        return transport
-    }()
-
-    static var deviceId: String = ""
-    static var tokenHelper: APITokenManagable?
-    static var graphQLAPIUrl: URL?
-    static var client: ApolloClient?
-
-    static func makeGraphQLManager(
-        deviceId: String,
-        tokenHelper: APITokenManagable,
-        graphQLAPIUrl: URL
-    ) -> GraphQLManageable? {
-        self.deviceId = deviceId
-        self.tokenHelper = tokenHelper
-        self.graphQLAPIUrl = graphQLAPIUrl
-        guard let networkTransport = networkTransport else { return nil }
-        client = ApolloClient(networkTransport: networkTransport, store: store)
-        guard let client = client else { return nil }
-        return GraphQLManager(client: client)
+        GraphQLManager.shared = GraphQLManager(
+            endpointUrl: graphQLAPIUrl,
+            store: store,
+            networkTransport: networkTransport,
+            client: ApolloClient(networkTransport: networkTransport, store: store))
+        return GraphQLManager.shared
     }
 }

--- a/Core/GraphQL/GraphQLFactory.swift
+++ b/Core/GraphQL/GraphQLFactory.swift
@@ -9,38 +9,53 @@
 import Foundation
 import Apollo
 
-public enum GraphQLFactory {
+public class GraphQLFactory {
+
+    static let store: ApolloStore = {
+        let documentsPath = NSSearchPathForDirectoriesInDomains(
+            .libraryDirectory,
+            .userDomainMask,
+            true).first ?? ""
+        let documentsUrl = URL(fileURLWithPath: documentsPath)
+        let sqliteFileUrl = documentsUrl.appendingPathComponent("realifetech_core_apollo_db.sqlite")
+        let sqliteCache = try? SQLiteNormalizedCache(fileURL: sqliteFileUrl)
+        return ApolloStore(cache: sqliteCache ?? InMemoryNormalizedCache())
+    }()
+
+    static let networkTransport: RequestChainNetworkTransport? = {
+        var headers: [String: String] = ["X-Ls-DeviceId": deviceId]
+        guard let tokenHelper = tokenHelper, let graphQLAPIUrl = graphQLAPIUrl else {
+            return nil
+        }
+        if tokenHelper.tokenIsValid, let token = tokenHelper.token {
+            headers["Authorization"] = "Bearer \(token)"
+        }
+        let transport = RequestChainNetworkTransport(
+            interceptorProvider: GraphQLInterceptorProvider(
+                store: store,
+                client: URLSessionClient(),
+                tokenHelper: tokenHelper),
+            endpointURL: graphQLAPIUrl,
+            additionalHeaders: headers)
+        return transport
+    }()
+
+    static var deviceId: String = ""
+    static var tokenHelper: APITokenManagable?
+    static var graphQLAPIUrl: URL?
+    static var client: ApolloClient?
 
     static func makeGraphQLManager(
         deviceId: String,
         tokenHelper: APITokenManagable,
         graphQLAPIUrl: URL
-    ) -> GraphQLManageable {
-        let store: ApolloStore = {
-            let documentsPath = NSSearchPathForDirectoriesInDomains(
-                .libraryDirectory,
-                .userDomainMask,
-                true).first ?? ""
-            let documentsUrl = URL(fileURLWithPath: documentsPath)
-            let sqliteFileUrl = documentsUrl.appendingPathComponent("realifetech_core_apollo_db.sqlite")
-            let sqliteCache = try? SQLiteNormalizedCache(fileURL: sqliteFileUrl)
-            return ApolloStore(cache: sqliteCache ?? InMemoryNormalizedCache())
-        }()
-        let networkTransport: RequestChainNetworkTransport = {
-            var headers: [String: String] = ["X-Ls-DeviceId": deviceId]
-            if tokenHelper.tokenIsValid, let token = tokenHelper.token {
-                headers["Authorization"] = "Bearer \(token)"
-            }
-            let transport = RequestChainNetworkTransport(
-                interceptorProvider: GraphQLInterceptorProvider(
-                    store: store,
-                    client: URLSessionClient(),
-                    tokenHelper: tokenHelper),
-                endpointURL: graphQLAPIUrl,
-                additionalHeaders: headers)
-            return transport
-        }()
-        let client = ApolloClient(networkTransport: networkTransport, store: store)
+    ) -> GraphQLManageable? {
+        self.deviceId = deviceId
+        self.tokenHelper = tokenHelper
+        self.graphQLAPIUrl = graphQLAPIUrl
+        guard let networkTransport = networkTransport else { return nil }
+        client = ApolloClient(networkTransport: networkTransport, store: store)
+        guard let client = client else { return nil }
         return GraphQLManager(client: client)
     }
 }

--- a/Core/GraphQL/GraphQLManager.swift
+++ b/Core/GraphQL/GraphQLManager.swift
@@ -25,9 +25,23 @@ public protocol GraphQLManageable {
 
 public class GraphQLManager {
 
+    public static var shared: GraphQLManager!
+
+    private(set) var networkTransport: NetworkTransport
+
+    public let endpointUrl: URL
+    private let store: ApolloStore
     private let client: ApolloClient
 
-    public init(client: ApolloClient) {
+    public init(
+        endpointUrl: URL,
+        store: ApolloStore,
+        networkTransport: NetworkTransport,
+        client: ApolloClient
+    ) {
+        self.endpointUrl = endpointUrl
+        self.store = store
+        self.networkTransport = networkTransport
         self.client = client
     }
 }

--- a/Core/GraphQL/Tests/GraphQLManagerTests.swift
+++ b/Core/GraphQL/Tests/GraphQLManagerTests.swift
@@ -20,8 +20,13 @@ final class GraphQLManagerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         networkTransport = MockNetworkTransport()
-        client = ApolloClient(networkTransport: networkTransport, store: ApolloStore())
-        sut = GraphQLManager(client: client)
+        let store = ApolloStore()
+        client = ApolloClient(networkTransport: networkTransport, store: store)
+        sut = GraphQLManager(
+            endpointUrl: URL(fileURLWithPath: ""),
+            store: store,
+            networkTransport: networkTransport,
+            client: client)
     }
 
     override func tearDown() {
@@ -117,7 +122,11 @@ final class GraphQLManagerTests: XCTestCase {
         let cache = MockCache()
         let store = ApolloStore(cache: cache)
         let client = ApolloClient(networkTransport: networkTransport, store: store)
-        sut = GraphQLManager(client: client)
+        sut = GraphQLManager(
+            endpointUrl: URL(fileURLWithPath: ""),
+            store: store,
+            networkTransport: networkTransport,
+            client: client)
         sut.clearAllCachedData {
             XCTAssertTrue(cache.clearGetsCalled)
             expectation.fulfill()

--- a/RealifeTech/RealifeTech.swift
+++ b/RealifeTech/RealifeTech.swift
@@ -36,10 +36,11 @@ public class RealifeTech {
             clientId: configuration.appCode,
             clientSecret: configuration.clientSecret,
             baseUrl: configuration.apiUrl)
-        let graphQLManager = GraphQLFactory.makeGraphQLManager(
+        guard let graphQLManager = GraphQLFactory.makeGraphQLManager(
             deviceId: deviceHelper.deviceId,
             tokenHelper: apiHelper,
             graphQLAPIUrl: URL(string: configuration.graphQLApiUrl) ?? URL(fileURLWithPath: ""))
+        else { return }
         Core = CoreImplementing(
             deviceHelper: deviceHelper,
             reachabilityHelper: reachabilityChecker,

--- a/RealifeTech/RealifeTech.swift
+++ b/RealifeTech/RealifeTech.swift
@@ -36,16 +36,15 @@ public class RealifeTech {
             clientId: configuration.appCode,
             clientSecret: configuration.clientSecret,
             baseUrl: configuration.apiUrl)
-        guard let graphQLManager = GraphQLFactory.makeGraphQLManager(
+        let graphQLManager = GraphQLFactory.makeGraphQLManager(
             deviceId: deviceHelper.deviceId,
             tokenHelper: apiHelper,
             graphQLAPIUrl: URL(string: configuration.graphQLApiUrl) ?? URL(fileURLWithPath: ""))
-        else { return }
         Core = CoreImplementing(
             deviceHelper: deviceHelper,
             reachabilityHelper: reachabilityChecker,
             apiHelper: apiHelper,
-            graphQLManager: graphQLManager,
+            graphQLManager: GraphQLManager.shared,
             diskCache: DiskCache())
         let staticDeviceInformation = StaticDeviceInformation(
             deviceId: deviceHelper.deviceId,
@@ -55,16 +54,16 @@ public class RealifeTech {
         General = GeneralFactory.makeGeneralModule(
             staticDeviceInformation: staticDeviceInformation,
             reachabilityChecker: reachabilityChecker)
-        Audiences = AudiencesImplementing(graphQLManager: graphQLManager)
+        Audiences = AudiencesImplementing(graphQLManager: GraphQLManager.shared)
         Analytics = AnalyticsFactory.makeAnalyticsModule(
             graphQLManager: graphQLManager,
             reachabilityHelper: reachabilityChecker,
             deviceRegistering: General)
         Communicate = CommunicateFactory.makeCommunicateModule()
-        Canvas = CanvasFactory.makeCanvasModule(graphQLManager: graphQLManager)
-        Content = ContentFactory.makeContentModule(graphQLManager: graphQLManager)
+        Canvas = CanvasFactory.makeCanvasModule(graphQLManager: GraphQLManager.shared)
+        Content = ContentFactory.makeContentModule(graphQLManager: GraphQLManager.shared)
         Sell = SellFactory.makeSellModule(
-            graphQLManager: graphQLManager,
+            graphQLManager: GraphQLManager.shared,
             orderingJourneyUrl: configuration.webOrderingJourneyUrl,
             colorStore: General)
     }


### PR DESCRIPTION
The crashing is caused by instantiating multiple ApolloStore so the app crashes on database locked on SQLite. Using singleton and keeping references on the GraphQLManager resolve the crashing.