### PR TITLE
MOD-290 ApolloClient headers wasn't updated when tokens are updated

### DIFF
--- a/Core/CoreImplementing.swift
+++ b/Core/CoreImplementing.swift
@@ -39,6 +39,7 @@ public class CoreImplementing: Core {
             accessToken: accessToken,
             secondsExpiresIn: secondsExpiresIn,
             refreshToken: refreshToken)
+        graphQLManager.updateHeadersToNetworkTransport(deviceId: deviceHelper.deviceId, apiHelper: apiHelper)
     }
 
     public func clearStoredCredentials() {

--- a/Core/GraphQL/Tests/GraphQLManagerTests.swift
+++ b/Core/GraphQL/Tests/GraphQLManagerTests.swift
@@ -133,6 +133,25 @@ final class GraphQLManagerTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 0.01)
     }
+
+    func test_updateHeadersToNetworkTransport_validToken_addBearerTokenToHeader() throws {
+        let apiHelper = SpyApiHelper()
+        apiHelper.tokenReturns = "token"
+        apiHelper.tokenIsValidReturns = true
+        sut.updateHeadersToNetworkTransport(deviceId: "A", apiHelper: apiHelper)
+        let transport = try XCTUnwrap(sut.networkTransport as? RequestChainNetworkTransport)
+        XCTAssertEqual(transport.additionalHeaders["X-Ls-DeviceId"], "A")
+        XCTAssertEqual(transport.additionalHeaders["Authorization"], "Bearer token")
+    }
+
+    func test_updateHeadersToNetworkTransport_invalidToken_doesntAdBearerTokenToHeader() throws {
+        let apiHelper = SpyApiHelper()
+        apiHelper.tokenIsValidReturns = false
+        sut.updateHeadersToNetworkTransport(deviceId: "A", apiHelper: apiHelper)
+        let transport = try XCTUnwrap(sut.networkTransport as? RequestChainNetworkTransport)
+        XCTAssertEqual(transport.additionalHeaders["X-Ls-DeviceId"], "A")
+        XCTAssertNil(transport.additionalHeaders["Authorization"])
+    }
 }
 
 private typealias UnderTestQuery = ApolloType.GetFulfilmentPointsQuery

--- a/Core/GraphQL/Tests/Utils/MockGraphQLManager.swift
+++ b/Core/GraphQL/Tests/Utils/MockGraphQLManager.swift
@@ -15,6 +15,7 @@ final class MockGraphQLManager<ResultDataType>: GraphQLManageable {
     var dispatchQueryIsCalled = false
     var dispatchMutationIsCalled = false
     var resultReturns: Result<GraphQLResult<ResultDataType>, Error> = .failure(DummyError.failure)
+    var newApiHelper: APITokenManagable?
 
     func dispatch<Query: GraphQLQuery>(
         query: Query,
@@ -43,4 +44,8 @@ final class MockGraphQLManager<ResultDataType>: GraphQLManageable {
     }
 
     func clearAllCachedData(completion: (() -> Void)?) { }
+
+    func updateHeadersToNetworkTransport(deviceId: String, apiHelper: APITokenManagable) {
+        newApiHelper = apiHelper
+    }
 }


### PR DESCRIPTION
Update ApolloClient and NetworkTransport whenever tokens are updated. The network transport and the client have to be setup again.