### PR TITLE
MOD-291 GraphQL JSON type might returns Array or Dictionary

### DIFF
--- a/GraphQL/JSON+Helper.swift
+++ b/GraphQL/JSON+Helper.swift
@@ -9,13 +9,17 @@
 import Foundation
 import Apollo
 
-public typealias JSON = [Any]
+public typealias JSON = [[String: String?]]
 
-extension Array: JSONDecodable {
+extension JSON: JSONDecodable {
 
     public init(jsonValue value: JSONValue) throws {
         guard let array = value as? Array else {
-          throw JSONDecodingError.couldNotConvert(value: value, to: Array.self)
+            guard let dict = value as? [String: String?] else {
+                throw JSONDecodingError.couldNotConvert(value: value, to: [String: String?].self)
+            }
+            self = [dict]
+            return
         }
         self = array
     }

--- a/Sell/Basket/Models/SeatInfo.swift
+++ b/Sell/Basket/Models/SeatInfo.swift
@@ -46,7 +46,7 @@ extension SeatInfo {
 
     init?(jsonValue value: JSON) {
         guard
-            let dic = value.first as? [String: String?],
+            let dic = value.first,
             let data = try? JSONSerialization.data(withJSONObject: dic, options: .prettyPrinted),
             let decoded = try? JSONDecoder().decode(SeatInfo.self, from: data)
         else {

--- a/Sell/Basket/Tests/SeatInfoTests.swift
+++ b/Sell/Basket/Tests/SeatInfoTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import GraphQL
 @testable import RealifeTech
 
 final class SeatInfoTests: XCTestCase {
@@ -43,8 +44,43 @@ final class SeatInfoTests: XCTestCase {
         XCTAssertNil(sut.table)
     }
 
-    func test_initWithJson_nonNilJsonWithMismatchedFirstType_returnsNil() throws {
-        let json: [Any] = ["a"]
-        XCTAssertNil(SeatInfo(json: json))
+    func test_initWithJsonValue_DictionaryType_returnsSeatInfo() throws {
+        let jsonValueDict: [String: String?] = [
+            "row": "A",
+            "seat": "B",
+            "block": "C",
+            "table": "D"
+        ]
+        let json = try JSON(jsonValue: jsonValueDict)
+        let sut = try XCTUnwrap(SeatInfo(json: json))
+        XCTAssertEqual(sut.row, "A")
+        XCTAssertEqual(sut.seat, "B")
+        XCTAssertEqual(sut.block, "C")
+        XCTAssertEqual(sut.table, "D")
+    }
+
+    func test_initWithJSONValue_ArrayType_returnsSeatInfo() throws {
+        let jsonValueArray: [[String: String?]] = [[
+            "row": "A",
+            "seat": "B",
+            "block": "C",
+            "table": "D"
+        ]]
+        let json = try JSON(jsonValue: jsonValueArray)
+        let sut = try XCTUnwrap(SeatInfo(json: json))
+        XCTAssertEqual(sut.row, "A")
+        XCTAssertEqual(sut.seat, "B")
+        XCTAssertEqual(sut.block, "C")
+        XCTAssertEqual(sut.table, "D")
+    }
+
+    func test_initWithJsonValue_notArrayOrDictionayType_returnsError() throws {
+        let jsonValueString = "a"
+        do {
+            let json = try JSON(jsonValue: jsonValueString)
+            XCTAssertNil(SeatInfo(json: json))
+        } catch let error {
+            XCTAssertNotNil(error)
+        }
     }
 }


### PR DESCRIPTION
Because BE sometimes returns JSON type as Array of dictionary (`[[String: String?]]`) (getMyBasket), and sometimes BE returns JSON type as Dictionary (`[String: String?]`) (getMyOrders)