### PR TITLE
MOD-661 Update GraphQL header after refreshing access token

### DIFF
--- a/Core/GraphQL/GraphQLFactory.swift
+++ b/Core/GraphQL/GraphQLFactory.swift
@@ -53,7 +53,8 @@ public struct GraphQLFactory {
             interceptorProvider: GraphQLInterceptorProvider(
                 store: store,
                 client: urlSessionClient,
-                tokenHelper: apiHelper),
+                tokenHelper: apiHelper,
+                deviceId: deviceId),
             endpointURL: graphQLAPIUrl,
             additionalHeaders: headers)
     }

--- a/Core/GraphQL/Interceptors/GraphQLInterceptorProvider.swift
+++ b/Core/GraphQL/Interceptors/GraphQLInterceptorProvider.swift
@@ -13,13 +13,14 @@ struct GraphQLInterceptorProvider: InterceptorProvider {
     let store: ApolloStore
     let client: URLSessionClient
     let tokenHelper: APITokenManagable
+    let deviceId: String
 
     func interceptors<Operation: GraphQLOperation>(for operation: Operation) -> [ApolloInterceptor] {
         return [
             LegacyCacheReadInterceptor(store: store),
             NetworkFetchInterceptor(client: client),
             RequestLoggingInterceptor(),
-            APITokenInterceptor(tokenHelper: tokenHelper),
+            APITokenInterceptor(tokenHelper: tokenHelper, deviceId: deviceId),
             ResponseCodeInterceptor(),
             LegacyParsingInterceptor(cacheKeyForObject: store.cacheKeyForObject),
             LegacyCacheWriteInterceptor(store: store)

--- a/Core/GraphQL/Tests/GraphQLInterceptorProviderTests.swift
+++ b/Core/GraphQL/Tests/GraphQLInterceptorProviderTests.swift
@@ -17,7 +17,8 @@ final class GraphQLInterceptorProviderTests: XCTestCase {
         let sut = GraphQLInterceptorProvider(
             store: ApolloStore(),
             client: MockURLSessionClient(),
-            tokenHelper: EmptyTokenManager())
+            tokenHelper: EmptyTokenManager(),
+            deviceId: "mockDeviceId")
         let interceptors = sut.interceptors(for: ApolloType.GetFulfilmentPointsQuery(pageSize: 10, params: nil))
         XCTAssertEqual(interceptors.count, 7)
         XCTAssertTrue(interceptors[0] is LegacyCacheReadInterceptor)

--- a/Core/GraphQL/Tests/Utils/MockGraphQLManager.swift
+++ b/Core/GraphQL/Tests/Utils/MockGraphQLManager.swift
@@ -16,6 +16,8 @@ final class MockGraphQLManager<ResultDataType>: GraphQLManageable {
     var dispatchMutationIsCalled = false
     var resultReturns: Result<GraphQLResult<ResultDataType>, Error> = .failure(DummyError.failure)
     var newApiHelper: APITokenManagable?
+    var receivedDeviceId: String?
+    var didCallUpdateHeadersToNetworkTransport = false
 
     func dispatch<Query: GraphQLQuery>(
         query: Query,
@@ -47,5 +49,7 @@ final class MockGraphQLManager<ResultDataType>: GraphQLManageable {
 
     func updateHeadersToNetworkTransport(deviceId: String, apiHelper: APITokenManagable) {
         newApiHelper = apiHelper
+        receivedDeviceId = deviceId
+        didCallUpdateHeadersToNetworkTransport = true
     }
 }

--- a/Core/GraphQL/Utils/GraphQLErrorCode.swift
+++ b/Core/GraphQL/Utils/GraphQLErrorCode.swift
@@ -1,0 +1,13 @@
+//
+//  GraphQLErrorCode.swift
+//  RealifeTech
+//
+//  Created by YOU-HSUAN YU on 2021/12/7.
+//  Copyright © 2021 Realife Tech. All rights reserved.
+//
+
+import Foundation
+
+enum GraphQLErrorCode: String {
+    case unauthenticated = "UNAUTHENTICATED"
+}

--- a/RealifeTech-SDK.podspec
+++ b/RealifeTech-SDK.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |spec|
 
   spec.name         = "RealifeTech-SDK"
   spec.module_name  = "RealifeTech"
-  spec.version      = "1.3.10"
+  spec.version      = "1.3.11"
   spec.summary      = "Providing integration with the RealifeTech Experience Automation Platform."
 
   spec.description  = "This is RealifeTech SDK, it provides integration with RealifeTech backend services, providing functionality such as device notification management, audience membership, and analytics logging. Creating a better experience of the real world for every person."

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0913A9BB2750B7B400DB9D99 /* PaymentOrderStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0913A9BA2750B7B400DB9D99 /* PaymentOrderStatus.swift */; };
 		0913A9DF275511B500DB9D99 /* Order+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0913A9DE275511B500DB9D99 /* Order+Extension.swift */; };
+		09860AFF275F35E300764142 /* GraphQLErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09860AFE275F35E300764142 /* GraphQLErrorCode.swift */; };
 		09A6F9FC26E7BD20009AF856 /* JSON+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A6F9FB26E7BD20009AF856 /* JSON+Helper.swift */; };
 		3E78BCF226B8231800BF3026 /* sell_updatePaymentIntent.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0319F2F92667995B00C01E1F /* sell_updatePaymentIntent.graphql.swift */; };
 		3E78BCF326B8231800BF3026 /* analytics_putAnalyticEvent.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0319F2F22667995A00C01E1F /* analytics_putAnalyticEvent.graphql.swift */; };
@@ -420,6 +421,7 @@
 		03EEB8B5252E08B400C868AD /* AudiencesImplementing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiencesImplementing.swift; sourceTree = "<group>"; };
 		0913A9BA2750B7B400DB9D99 /* PaymentOrderStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentOrderStatus.swift; sourceTree = "<group>"; };
 		0913A9DE275511B500DB9D99 /* Order+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+Extension.swift"; sourceTree = "<group>"; };
+		09860AFE275F35E300764142 /* GraphQLErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLErrorCode.swift; sourceTree = "<group>"; };
 		09A6F9FB26E7BD20009AF856 /* JSON+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSON+Helper.swift"; sourceTree = "<group>"; };
 		1AEB0DA8BD2631E8F26720C5 /* Pods-RealifeTech-RealifeTechTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealifeTech-RealifeTechTests.release.xcconfig"; path = "Target Support Files/Pods-RealifeTech-RealifeTechTests/Pods-RealifeTech-RealifeTechTests.release.xcconfig"; sourceTree = "<group>"; };
 		3702AE9C18F340B82ED9978C /* Pods-RealifeTech.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealifeTech.debug.xcconfig"; path = "Target Support Files/Pods-RealifeTech/Pods-RealifeTech.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1219,6 +1221,7 @@
 			children = (
 				9606ED85267B504900ED24D0 /* PaginatedObject.swift */,
 				961C1CDC2685F86200BE6F3B /* String+ISO8601Date.swift */,
+				09860AFE275F35E300764142 /* GraphQLErrorCode.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2333,6 +2336,7 @@
 				4889595C2539D89C00B978A9 /* AnalyticsLogging.swift in Sources */,
 				961C41E9260882BA001D8467 /* StandardSenderResponse.swift in Sources */,
 				961C41FF260882BB001D8467 /* APITokenInterceptor.swift in Sources */,
+				09860AFF275F35E300764142 /* GraphQLErrorCode.swift in Sources */,
 				96AED8CE26CFB58A00F6C750 /* Color+Hex.swift in Sources */,
 				961C4215260882BB001D8467 /* DiskCache.swift in Sources */,
 				961C4268260882C8001D8467 /* PersistentQueue.swift in Sources */,

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -2697,7 +2697,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.10;
+				MARKETING_VERSION = 1.3.11;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.concertlive.RealifeTech;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -2730,7 +2730,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.10;
+				MARKETING_VERSION = 1.3.11;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.concertlive.RealifeTech;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";


### PR DESCRIPTION
**Issue**:
After access token expired, the following GraphQL calls are being triggered twice (for the same request).
The first one returns status code `400` with `"UNAUTHENTICATED"` error. And when status code == 400, we add updated header in the request and then trigger `retry`, so the second request returns `200` (succeeded)

![before](https://user-images.githubusercontent.com/77625840/144441429-b0a9087a-97f3-4408-b61b-21b638118d12.png)

**Root cause:**
We didn't update GraphQL header after token is being refreshed.

**Changes here:**
- If errors extenstions.code == `"UNAUTHENTICATED"`, we should refresh token
- call `updateHeadersToNetworkTransport` after getting the new token, in order to update GraphQL

![after](https://user-images.githubusercontent.com/77625840/144550389-6b095531-c7f3-4b04-926a-dfc12ebdb68c.png)
