### PR TITLE
CTD-1869 FPS not updating in FP Category List when changing experience

### DIFF
--- a/Sell/FulfilmentPoint/Repository/FulfilmentPointRepository.swift
+++ b/Sell/FulfilmentPoint/Repository/FulfilmentPointRepository.swift
@@ -83,7 +83,7 @@ extension FulfilmentPointRepository: FulfilmentPointProvidable {
     ) {
         graphQLManager.dispatch(
             query: ApolloType.GetFulfilmentPointCategoriesQuery(pageSize: pageSize, page: page),
-            cachePolicy: .returnCacheDataAndFetch
+            cachePolicy: .fetchIgnoringCacheData
         ) { result in
             switch result {
             case .success(let response):


### PR DESCRIPTION
Hey @rossrossp @You-Hsuan I wanted to get your opinion on this bug and fix, maybe you had a similar problem before. The problem is when a user changes venue and after that tries to change the location - that is requesting fulfilment point categories (request `getFulfilmentPointCategories`), the request first returns cached data and a modal view is presented with that old data. To fix this we can just change the cache policy and everything will work. Do you think that is a suitable solution? 