### PR TITLE
CATD-544 Fixed headers doesn't refresh with new token issue

### DIFF
--- a/Core/GraphQL/GraphQLFactory.swift
+++ b/Core/GraphQL/GraphQLFactory.swift
@@ -53,8 +53,7 @@ public struct GraphQLFactory {
             interceptorProvider: GraphQLInterceptorProvider(
                 store: store,
                 client: urlSessionClient,
-                tokenHelper: apiHelper,
-                deviceId: deviceId),
+                tokenHelper: apiHelper),
             endpointURL: graphQLAPIUrl,
             additionalHeaders: headers)
     }

--- a/Core/GraphQL/Interceptors/APITokenInterceptor.swift
+++ b/Core/GraphQL/Interceptors/APITokenInterceptor.swift
@@ -11,17 +11,9 @@ import Apollo
 class APITokenInterceptor: ApolloInterceptor {
 
     private let tokenHelper: APITokenManagable
-    private let graphQLManager: GraphQLManageable
-    private let deviceId: String
 
-    init(
-        tokenHelper: APITokenManagable,
-        graphQLManager: GraphQLManageable = GraphQLManager.shared,
-        deviceId: String
-    ) {
+    init(tokenHelper: APITokenManagable) {
         self.tokenHelper = tokenHelper
-        self.graphQLManager = graphQLManager
-        self.deviceId = deviceId
     }
 
     func interceptAsync<Operation: GraphQLOperation>(
@@ -29,55 +21,12 @@ class APITokenInterceptor: ApolloInterceptor {
         request: HTTPRequest<Operation>,
         response: HTTPResponse<Operation>?,
         completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) {
-        guard let receivedResponse = response else {
-            chain.handleErrorAsync(
-                ResponseCodeInterceptor.ResponseCodeError.invalidResponseCode(
-                    response: response?.httpResponse,
-                    rawData: response?.rawData),
-                request: request,
-                response: response,
-                completion: completion)
-            return
+        if let token = tokenHelper.token, tokenHelper.tokenIsValid {
+            request.addHeader(name: "Authorization", value: "Bearer \(token)")
         }
-        if let graphQLErrorCode = try? convertToGraphQLErrorCode(receivedResponse.rawData),
-           graphQLErrorCode == .unauthenticated {
-            tokenHelper.getValidToken { [self] _ in
-                guard let token = tokenHelper.token, tokenHelper.tokenIsValid else { return }
-                graphQLManager.updateHeadersToNetworkTransport(
-                    deviceId: deviceId,
-                    apiHelper: tokenHelper)
-                request.addHeader(name: "Authorization", value: "Bearer \(token)")
-                chain.retry(request: request, completion: completion)
-            }
-        } else {
-            chain.proceedAsync(
-                request: request,
-                response: response,
-                completion: completion)
-        }
-    }
-
-    // Note: When access token expired, GraphQL response returns this error:
-    /*
-     { "errors": [
-           { "message": "Context creation failed: Access denied: Invalid auth token",
-             "extensions": {
-               "code": "UNAUTHENTICATED",
-                ...
-             }}]
-     }
-     */
-    private func convertToGraphQLErrorCode(_ data: Data) throws -> GraphQLErrorCode? {
-        do {
-            guard let json = try? JSONSerializationFormat.deserialize(data: data) as? JSONObject,
-                  let errors = json["errors"] as? [JSONObject],
-                  let firstGraphQLErrorJson = errors.first,
-                  let extensions = GraphQLError(firstGraphQLErrorJson).extensions,
-                  let code = extensions["code"] as? String
-            else {
-                return nil
-            }
-            return GraphQLErrorCode(rawValue: code)
-        }
+        chain.proceedAsync(
+            request: request,
+            response: response,
+            completion: completion)
     }
 }

--- a/Core/GraphQL/Interceptors/GraphQLInterceptorProvider.swift
+++ b/Core/GraphQL/Interceptors/GraphQLInterceptorProvider.swift
@@ -13,17 +13,17 @@ struct GraphQLInterceptorProvider: InterceptorProvider {
     let store: ApolloStore
     let client: URLSessionClient
     let tokenHelper: APITokenManagable
-    let deviceId: String
 
     func interceptors<Operation: GraphQLOperation>(for operation: Operation) -> [ApolloInterceptor] {
         return [
-            LegacyCacheReadInterceptor(store: store),
+            APITokenInterceptor(tokenHelper: tokenHelper),
+            MaxRetryInterceptor(),
+            CacheReadInterceptor(store: store),
             NetworkFetchInterceptor(client: client),
             RequestLoggingInterceptor(),
-            APITokenInterceptor(tokenHelper: tokenHelper, deviceId: deviceId),
-            ResponseCodeInterceptor(),
-            LegacyParsingInterceptor(cacheKeyForObject: store.cacheKeyForObject),
-            LegacyCacheWriteInterceptor(store: store)
+            ResponseInterceptor(tokenHelper: tokenHelper),
+            JSONResponseParsingInterceptor(cacheKeyForObject: store.cacheKeyForObject),
+            CacheWriteInterceptor(store: store)
         ]
     }
 }

--- a/Core/GraphQL/Interceptors/ResponseInterceptor.swift
+++ b/Core/GraphQL/Interceptors/ResponseInterceptor.swift
@@ -1,0 +1,70 @@
+//
+//  ResponseInterceptor.swift
+//  RealifeTech-SDK
+//
+//  Created by YOU-HSUAN YU on 2022/5/17.
+//
+
+import Foundation
+import Apollo
+
+class ResponseInterceptor: ApolloInterceptor {
+
+    private let tokenHelper: APITokenManagable
+
+    init(tokenHelper: APITokenManagable) {
+        self.tokenHelper = tokenHelper
+    }
+
+    func interceptAsync<Operation>(
+        chain: RequestChain,
+        request: HTTPRequest<Operation>,
+        response: HTTPResponse<Operation>?,
+        completion: @escaping (Result<GraphQLResult<Operation.Data>, Error>) -> Void) {
+            if let graphQLErrorCode = try? convertToGraphQLErrorCode(response?.rawData),
+               graphQLErrorCode == .unauthenticated {
+                tokenHelper.getValidToken { result in
+                    switch result {
+                    case .success(_) :
+                        chain.retry(request: request, completion: completion)
+                    case .failure(let error):
+                        chain.handleErrorAsync(
+                            error,
+                            request: request,
+                            response: response,
+                            completion: completion)
+                    }
+                }
+            } else {
+                chain.proceedAsync(
+                    request: request,
+                    response: response,
+                    completion: completion)
+            }
+    }
+
+    // Note: When access token expired, GraphQL response returns this error:
+    /*
+     { "errors": [
+           { "message": "Context creation failed: Access denied: Invalid auth token",
+             "extensions": {
+               "code": "UNAUTHENTICATED",
+                ...
+             }}]
+     }
+     */
+    private func convertToGraphQLErrorCode(_ data: Data?) throws -> GraphQLErrorCode? {
+        do {
+            guard let data = data,
+                  let json = try? JSONSerializationFormat.deserialize(data: data) as? JSONObject,
+                  let errors = json["errors"] as? [JSONObject],
+                  let firstGraphQLErrorJson = errors.first,
+                  let extensions = GraphQLError(firstGraphQLErrorJson).extensions,
+                  let code = extensions["code"] as? String
+            else {
+                return nil
+            }
+            return GraphQLErrorCode(rawValue: code)
+        }
+    }
+}

--- a/Core/GraphQL/Tests/GraphQLInterceptorProviderTests.swift
+++ b/Core/GraphQL/Tests/GraphQLInterceptorProviderTests.swift
@@ -17,17 +17,17 @@ final class GraphQLInterceptorProviderTests: XCTestCase {
         let sut = GraphQLInterceptorProvider(
             store: ApolloStore(),
             client: MockURLSessionClient(),
-            tokenHelper: EmptyTokenManager(),
-            deviceId: "mockDeviceId")
+            tokenHelper: EmptyTokenManager())
         let interceptors = sut.interceptors(for: ApolloType.GetFulfilmentPointsQuery(pageSize: 10, params: nil))
-        XCTAssertEqual(interceptors.count, 7)
-        XCTAssertTrue(interceptors[0] is LegacyCacheReadInterceptor)
-        XCTAssertTrue(interceptors[1] is NetworkFetchInterceptor)
-        XCTAssertTrue(interceptors[2] is RequestLoggingInterceptor)
-        XCTAssertTrue(interceptors[3] is APITokenInterceptor)
-        XCTAssertTrue(interceptors[4] is ResponseCodeInterceptor)
-        XCTAssertTrue(interceptors[5] is LegacyParsingInterceptor)
-        XCTAssertTrue(interceptors[6] is LegacyCacheWriteInterceptor)
+        XCTAssertEqual(interceptors.count, 8)
+        XCTAssertTrue(interceptors[0] is APITokenInterceptor)
+        XCTAssertTrue(interceptors[1] is MaxRetryInterceptor)
+        XCTAssertTrue(interceptors[2] is CacheReadInterceptor)
+        XCTAssertTrue(interceptors[3] is NetworkFetchInterceptor)
+        XCTAssertTrue(interceptors[4] is RequestLoggingInterceptor)
+        XCTAssertTrue(interceptors[5] is ResponseInterceptor)
+        XCTAssertTrue(interceptors[6] is JSONResponseParsingInterceptor)
+        XCTAssertTrue(interceptors[7] is CacheWriteInterceptor)
     }
 }
 

--- a/Core/GraphQL/Tests/GraphQLManagerTests.swift
+++ b/Core/GraphQL/Tests/GraphQLManagerTests.swift
@@ -205,6 +205,8 @@ private final class MockCache: NormalizedCache {
 
     func removeRecord(for key: CacheKey) throws { }
 
+    func removeRecords(matching pattern: CacheKey) throws { }
+
     func clear() throws {
         clearGetsCalled = true
     }

--- a/Core/GraphQL/Tests/ResponseInterceptorTests.swift
+++ b/Core/GraphQL/Tests/ResponseInterceptorTests.swift
@@ -1,0 +1,87 @@
+//
+//  ResponseInterceptorTests.swift
+//  RealifeTechTests
+//
+//  Created by YOU-HSUAN YU on 2022/5/17.
+//  Copyright © 2022 Realife Tech. All rights reserved.
+//
+
+import XCTest
+import Apollo
+import GraphQL
+@testable import RealifeTech
+
+class ResponseInterceptorTests: XCTestCase {
+
+    private var sut: ResponseInterceptor!
+    private var tokenHelper: MockTokenHelper!
+    private var url: URL!
+
+    private let operation = ApolloType.GetFulfilmentPointsQuery(pageSize: 10, params: nil)
+    private lazy var request = MockRequest<ApolloType.GetFulfilmentPointsQuery>(
+        graphQLEndpoint: url,
+        operation: operation,
+        contentType: "",
+        clientName: "",
+        clientVersion: "",
+        additionalHeaders: [:])
+
+    override func setUp() {
+        super.setUp()
+        tokenHelper = MockTokenHelper()
+        url = URL(string: "localhost://")
+        sut = ResponseInterceptor(tokenHelper: tokenHelper)
+    }
+
+    override func tearDown() {
+        url = nil
+        tokenHelper = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    func test_interceptAsync_UnauthenticatedError_shouldCallGetValidToken() throws {
+        let expectation = XCTestExpectation(description: "Should make getValidToken call")
+        let response = try XCTUnwrap(makeHttpResponse(statusCode: 400))
+        sut.interceptAsync(
+            chain: RequestChain(interceptors: [sut]),
+            request: request,
+            response: response
+        ) { _ in
+            XCTAssertTrue(self.tokenHelper.getValidTokenCalled)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.01)
+    }
+
+    private func makeHttpResponse(statusCode: Int) throws -> HTTPResponse<ApolloType.GetFulfilmentPointsQuery> {
+        let response = try XCTUnwrap(
+            HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: nil)
+        )
+        return HTTPResponse<ApolloType.GetFulfilmentPointsQuery>(
+            response: response,
+            rawData: statusCode == 200 ? Data() : makeUnauthenticatedErrorData(),
+            parsedResponse: nil)
+    }
+
+    private func makeUnauthenticatedErrorData() -> Data {
+        let unauthenticatedError = #"""
+            { "errors": [
+                  {
+                    "message": "Context creation failed: Access denied: Invalid auth token",
+                    "extensions": {
+                      "code": "UNAUTHENTICATED"
+                    }
+                  }
+                ]
+            }
+        """#
+        return unauthenticatedError.data(using: .utf8) ?? Data()
+    }
+}
+
+private final class MockRequest<Operation: GraphQLOperation>: HTTPRequest<Operation> { }

--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ project 'RealifeTech-SDK'
 pod 'SwiftLint', '~> 0.43.1'
 pod 'RxSwift', '~> 6.1.0'
 pod 'RxCocoa', '~> 6.1.0'
-pod 'Apollo', '~> 0.40.0'
+pod 'Apollo', '~> 0.51.2'
 pod 'Apollo/SQLite'
 
 target 'RealifeTech' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Apollo (0.40.0):
-    - Apollo/Core (= 0.40.0)
-  - Apollo/Core (0.40.0)
-  - Apollo/SQLite (0.40.0):
+  - Apollo (0.51.2):
+    - Apollo/Core (= 0.51.2)
+  - Apollo/Core (0.51.2)
+  - Apollo/SQLite (0.51.2):
     - Apollo/Core
-    - SQLite.swift (~> 0.12.2)
+    - SQLite.swift (~> 0.13.1)
   - RxCocoa (6.1.0):
     - RxRelay (= 6.1.0)
     - RxSwift (= 6.1.0)
@@ -13,14 +13,14 @@ PODS:
   - RxSwift (6.1.0)
   - RxTest (6.1.0):
     - RxSwift (= 6.1.0)
-  - SQLite.swift (0.12.2):
-    - SQLite.swift/standard (= 0.12.2)
-  - SQLite.swift/standard (0.12.2)
+  - SQLite.swift (0.13.3):
+    - SQLite.swift/standard (= 0.13.3)
+  - SQLite.swift/standard (0.13.3)
   - SwiftLint (0.43.1)
   - ViewInspector (0.8.1)
 
 DEPENDENCIES:
-  - Apollo (~> 0.40.0)
+  - Apollo (~> 0.51.2)
   - Apollo/SQLite
   - RxCocoa (~> 6.1.0)
   - RxSwift (~> 6.1.0)
@@ -30,26 +30,26 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
+    - Apollo
+    - SQLite.swift
     - ViewInspector
   trunk:
-    - Apollo
     - RxCocoa
     - RxRelay
     - RxSwift
     - RxTest
-    - SQLite.swift
     - SwiftLint
 
 SPEC CHECKSUMS:
-  Apollo: 9fb70b598511a6212a81a34c00fa9bf8bac19a23
+  Apollo: e5bc805c3f3556c18edc4eae4e2ea4723cea2318
   RxCocoa: 5c51f02d562cbd94629f6c26cf0c80fe4ab8d343
   RxRelay: 483e1a19fad961b41f0b0c0bee506f46c1ae14fe
   RxSwift: a834e5c538e89eca0cae86f403f4fbf0336786ce
   RxTest: 9d26616eaff4a7e75f4ecae9b2c24840f2e8218d
-  SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
+  SQLite.swift: 903bfa3bc9ab06345fdfbb578e34f47cfcf417da
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   ViewInspector: 8f12eb0709a6159991afc8d7b27fae72cca50dc6
 
-PODFILE CHECKSUM: 9216457abc060dda06da210817957a6ca1225e53
+PODFILE CHECKSUM: 38a1f60fb6875f531f4ae07bfe0d8133682b2dd6
 
 COCOAPODS: 1.10.1

--- a/RealifeTech-SDK.podspec
+++ b/RealifeTech-SDK.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'RxSwift', '~> 6.1.0'
   spec.dependency 'RxCocoa', '~> 6.1.0'
-  spec.dependency 'Apollo', '~> 0.40.0'
+  spec.dependency 'Apollo', '~> 0.51.2'
   spec.dependency 'Apollo/SQLite'
   spec.dependency 'SwiftLint', '~> 0.43.1'
 

--- a/RealifeTech-SDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-SDK.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		09008ECE27E1F74200F6155D /* ProductModifierItemStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09008ECD27E1F74200F6155D /* ProductModifierItemStatus.swift */; };
 		0913A9BB2750B7B400DB9D99 /* PaymentOrderStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0913A9BA2750B7B400DB9D99 /* PaymentOrderStatus.swift */; };
 		0913A9DF275511B500DB9D99 /* Order+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0913A9DE275511B500DB9D99 /* Order+Extension.swift */; };
+		0958500F2833B1C1008E0DAB /* ResponseInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0958500E2833B1C1008E0DAB /* ResponseInterceptor.swift */; };
+		095850112833B4A2008E0DAB /* ResponseInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095850102833B4A2008E0DAB /* ResponseInterceptorTests.swift */; };
 		09860AFF275F35E300764142 /* GraphQLErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09860AFE275F35E300764142 /* GraphQLErrorCode.swift */; };
 		09A6F9FC26E7BD20009AF856 /* JSON+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A6F9FB26E7BD20009AF856 /* JSON+Helper.swift */; };
 		3E0C2595276215C700B6F7D1 /* RLTBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0C2594276215C700B6F7D1 /* RLTBannerFactoryTests.swift */; };
@@ -366,6 +368,8 @@
 		09008ECD27E1F74200F6155D /* ProductModifierItemStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductModifierItemStatus.swift; sourceTree = "<group>"; };
 		0913A9BA2750B7B400DB9D99 /* PaymentOrderStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentOrderStatus.swift; sourceTree = "<group>"; };
 		0913A9DE275511B500DB9D99 /* Order+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+Extension.swift"; sourceTree = "<group>"; };
+		0958500E2833B1C1008E0DAB /* ResponseInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseInterceptor.swift; sourceTree = "<group>"; };
+		095850102833B4A2008E0DAB /* ResponseInterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseInterceptorTests.swift; sourceTree = "<group>"; };
 		09860AFE275F35E300764142 /* GraphQLErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLErrorCode.swift; sourceTree = "<group>"; };
 		09A6F9FB26E7BD20009AF856 /* JSON+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSON+Helper.swift"; sourceTree = "<group>"; };
 		1AEB0DA8BD2631E8F26720C5 /* Pods-RealifeTech-RealifeTechTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealifeTech-RealifeTechTests.release.xcconfig"; path = "Target Support Files/Pods-RealifeTech-RealifeTechTests/Pods-RealifeTech-RealifeTechTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1122,6 +1126,7 @@
 				961C4188260882BA001D8467 /* GraphQLInterceptorProvider.swift */,
 				961C419A260882BA001D8467 /* APITokenInterceptor.swift */,
 				961C4186260882BA001D8467 /* RequestLoggingInterceptor.swift */,
+				0958500E2833B1C1008E0DAB /* ResponseInterceptor.swift */,
 			);
 			path = Interceptors;
 			sourceTree = "<group>";
@@ -1182,6 +1187,7 @@
 			isa = PBXGroup;
 			children = (
 				96302CE526C3E9EA000A91EC /* APITokenInterceptorTests.swift */,
+				095850102833B4A2008E0DAB /* ResponseInterceptorTests.swift */,
 				96302CDF26C3E4A7000A91EC /* GraphNetworkCachePolicyTests.swift */,
 				961C1C97268240CF00BE6F3B /* GraphQLFactoryTests.swift */,
 				96302CE326C3E899000A91EC /* GraphQLInterceptorProviderTests.swift */,
@@ -2296,6 +2302,7 @@
 				961C1CCF2684EF9C00BE6F3B /* ProductModifierItemSelectionInput.swift in Sources */,
 				964D290326932CDC00A69FBC /* CoreImplementing.swift in Sources */,
 				961C41D3260882BA001D8467 /* OAuthTokenRefreshWatcher.swift in Sources */,
+				0958500F2833B1C1008E0DAB /* ResponseInterceptor.swift in Sources */,
 				961C4211260882BB001D8467 /* ReadOnlyCurrentValue.swift in Sources */,
 				961C41D1260882BA001D8467 /* AuthorisationStore.swift in Sources */,
 				9637475926C54545007DF92D /* PaymentIntentNextAction.swift in Sources */,
@@ -2542,6 +2549,7 @@
 				488A67C62541DA8B005C030E /* AnalyticsLoggerTests.swift in Sources */,
 				9637475B26C546A7007DF92D /* PaymentIntentNextActionTests.swift in Sources */,
 				961C42982608830E001D8467 /* DeviceTokenTests.swift in Sources */,
+				095850112833B4A2008E0DAB /* ResponseInterceptorTests.swift in Sources */,
 				9606EDC0267CBF4E00ED24D0 /* DummyError.swift in Sources */,
 				9687488C268DB9A400DDC5DD /* PaymentRepositoryTestHelper.swift in Sources */,
 				96302CE626C3E9EA000A91EC /* APITokenInterceptorTests.swift in Sources */,

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - Apollo (0.40.0):
-    - Apollo/Core (= 0.40.0)
-  - Apollo/Core (0.40.0)
-  - Apollo/SQLite (0.40.0):
+  - Apollo (0.51.2):
+    - Apollo/Core (= 0.51.2)
+  - Apollo/Core (0.51.2)
+  - Apollo/SQLite (0.51.2):
     - Apollo/Core
-    - SQLite.swift (~> 0.12.2)
-  - RealifeTech-SDK (1.3.17):
-    - Apollo (~> 0.40.0)
+    - SQLite.swift (~> 0.13.1)
+  - RealifeTech-SDK (1.3.18):
+    - Apollo (~> 0.51.2)
     - Apollo/SQLite
     - RxCocoa (~> 6.1.0)
     - RxSwift (~> 6.1.0)
@@ -17,9 +17,9 @@ PODS:
   - RxRelay (6.1.0):
     - RxSwift (= 6.1.0)
   - RxSwift (6.1.0)
-  - SQLite.swift (0.12.2):
-    - SQLite.swift/standard (= 0.12.2)
-  - SQLite.swift/standard (0.12.2)
+  - SQLite.swift (0.13.3):
+    - SQLite.swift/standard (= 0.13.3)
+  - SQLite.swift/standard (0.13.3)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
@@ -39,12 +39,12 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Apollo: 9fb70b598511a6212a81a34c00fa9bf8bac19a23
-  RealifeTech-SDK: 3c1b9cbf85a63ba722e5590913918013730b8a57
+  Apollo: e5bc805c3f3556c18edc4eae4e2ea4723cea2318
+  RealifeTech-SDK: 2a269536763196bc8510c5fd9fe481e6b901ad70
   RxCocoa: 5c51f02d562cbd94629f6c26cf0c80fe4ab8d343
   RxRelay: 483e1a19fad961b41f0b0c0bee506f46c1ae14fe
   RxSwift: a834e5c538e89eca0cae86f403f4fbf0336786ce
-  SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
+  SQLite.swift: 903bfa3bc9ab06345fdfbb578e34f47cfcf417da
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
 PODFILE CHECKSUM: 3973cac1692e79e8c048bdca71ce97ff281aa725

--- a/SampleApp/SampleApp/Screens/Util/NotificationRegistrationHelper.swift
+++ b/SampleApp/SampleApp/Screens/Util/NotificationRegistrationHelper.swift
@@ -5,7 +5,7 @@
 //  Created by YOU-HSUAN YU on 2022/4/26.
 //  Copyright © 2022 Realife Tech. All rights reserved.
 //
- 
+
 import UIKit
 
 final class NotificationRegistrationHelper {


### PR DESCRIPTION
**Background:**
We found an issue that two GraphQL identical calls are made each time one after the other.
The first one fails with “UNAUTHENTICATED“ error, and the next call is a success.

**Root cause:**
The issue happened when the auth token has expired, and the first call did not updated with the new token in the header.

**Fixed:**
1. For `GraphQLInterceptorProvider.interceptors()` function, we should return `APITokenInterceptor` object as the first item.
2. Remove the logic for checking the "UNAUTHENTICATED" response from `APITokenInterceptor` as it should only be responsible for pre-network action which means adding the auth tokens to headers if needed.
3. As for the check of "UNAUTHENTICATED" error response, I created `ResponseInterceptor` new object to handle the response: when `error.extensions.code == "UNAUTHENTICATED"`, app should get valid token and then retry the request chain.
4. Update Apollo framework version to 0.51.2 (to keep up with their latest version and fixes)

Reference: Apollo document https://www.apollographql.com/docs/ios/v1/request-pipeline/